### PR TITLE
Feature/case management/make case type filter readonly

### DIFF
--- a/src/Indice.Features.Cases.App/package.json
+++ b/src/Indice.Features.Cases.App/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "17.3.8",
     "@angular/router": "17.3.8",
     "@indice/ng-auth": "^0.3.0",
-    "@indice/ng-components": "0.3.9-beta.1",
+    "@indice/ng-components": "0.3.9-beta.2",
     "@ngx-translate/core": "^15.0.0",
     "@ngx-translate/http-loader": "^8.0.0",
     "@types/lodash": "^4.14.180",

--- a/src/Indice.Features.Cases.App/package.json
+++ b/src/Indice.Features.Cases.App/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "17.3.8",
     "@angular/router": "17.3.8",
     "@indice/ng-auth": "^0.3.0",
-    "@indice/ng-components": "0.3.8",
+    "@indice/ng-components": "0.3.9-beta.0",
     "@ngx-translate/core": "^15.0.0",
     "@ngx-translate/http-loader": "^8.0.0",
     "@types/lodash": "^4.14.180",

--- a/src/Indice.Features.Cases.App/package.json
+++ b/src/Indice.Features.Cases.App/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "17.3.8",
     "@angular/router": "17.3.8",
     "@indice/ng-auth": "^0.3.0",
-    "@indice/ng-components": "0.3.9-beta.0",
+    "@indice/ng-components": "0.3.9-beta.1",
     "@ngx-translate/core": "^15.0.0",
     "@ngx-translate/http-loader": "^8.0.0",
     "@types/lodash": "^4.14.180",

--- a/src/Indice.Features.Cases.App/src/app/features/cases/case-type-specific-cases/case-type-specific-cases.component.ts
+++ b/src/Indice.Features.Cases.App/src/app/features/cases/case-type-specific-cases/case-type-specific-cases.component.ts
@@ -58,7 +58,8 @@ export class CaseTypeSpecificCasesComponent extends GeneralCasesComponent implem
       name: 'ΤΥΠΟΣ ΥΠΟΘΕΣΗΣ',
       dataType: 'array',
       options: [],
-      multiTerm: true
+      multiTerm: true,
+      readonly: true
     }
     const code = this.getFilterCacheKey();
     const caseType = caseTypes.items?.find(x => x.code == code);

--- a/src/Indice.Features.Cases.UI/CHANGELOG.md
+++ b/src/Indice.Features.Cases.UI/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Upcoming changes
+- The selected specific case type that is selected by the side navbar menu (navlinks) is now being displayed in the title
+- When clicking on specific case type from the menu, the filter can now no longer be removed
+
 ## [7.23.2] - 2024-06-05
 ### Added
 - Added `IsMenuItem` property to CaseType, you can now have all your cases displayed in a separate category as a menu item based on their case type


### PR DESCRIPTION
When clicking on specific case type from the menu, the filter can now no longer be removed