### PR TITLE
Fix Bearer token not passing validation

### DIFF
--- a/src/Indice.AspNetCore/Indice.AspNetCore.csproj
+++ b/src/Indice.AspNetCore/Indice.AspNetCore.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.3" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.6.14" />
     <PackageReference Include="MiniValidation" Version="0.9.0" />

--- a/src/Indice.Features.Identity.Core/TokenCreation/ExtendedTokenCreationService.cs
+++ b/src/Indice.Features.Identity.Core/TokenCreation/ExtendedTokenCreationService.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using IdentityServer4.Models;
 using System.Globalization;
 using IdentityServer4.Internal.Extensions;
+using IdentityServer4.Extensions;
 
 namespace Indice.Features.Identity.Core.TokenCreation;
 
@@ -115,7 +116,7 @@ public class ExtendedTokenCreationService : ITokenCreationService
         payload.AddClaims(normalClaims);
 
         // scope claims
-        if (!scopeClaims.IsNullOrEmpty()) {
+        if (!IEnumerableExtensions.IsNullOrEmpty(scopeClaims)) {
             var scopeValues = scopeClaims.Select(x => x.Value).ToArray();
 
             if (_options.EmitScopesAsSpaceDelimitedStringInJwt) {
@@ -126,7 +127,7 @@ public class ExtendedTokenCreationService : ITokenCreationService
         }
 
         // amr claims
-        if (!amrClaims.IsNullOrEmpty()) {
+        if (!IEnumerableExtensions.IsNullOrEmpty(amrClaims)) {
             var amrValues = amrClaims.Select(x => x.Value).Distinct().ToArray();
             payload.Add(JwtClaimTypes.AuthenticationMethod, amrValues);
         }


### PR DESCRIPTION
Fix Bearer token not passing validation because security keys differ from .NET 7 and .NET 8 version of the Nuget package

**Error message:**
`Bearer was not authenticated. Failure message: IDX10500: Signature validation failed. No security keys were provided to validate the signature.`

**More details here:**
https://stackoverflow.com/questions/60635967/idx10500-signature-validation-failed-no-security-keys-were-provided-to-validat
