### PR TITLE
Add InteractionMode property to otp purpose during device authentication

### DIFF
--- a/src/Indice.Features.Identity.Core/DeviceAuthentication/Configuration/Constants.cs
+++ b/src/Indice.Features.Identity.Core/DeviceAuthentication/Configuration/Constants.cs
@@ -6,9 +6,9 @@ namespace Indice.Features.Identity.Core.DeviceAuthentication.Configuration;
 internal class Constants
 {
     public static string DeviceAuthenticationOtpPurpose(string userId, string deviceId, InteractionMode interactionMode) => 
-        $"device-registration:{userId}:{deviceId}:{interactionMode}";
+        $"device-registration:{interactionMode}:{userId}:{deviceId}";
 
-    public static readonly string[] ProtocolClaimsFilter = {
+    public static readonly string[] ProtocolClaimsFilter = [
         JwtClaimTypes.AccessTokenHash,
         JwtClaimTypes.Audience,
         JwtClaimTypes.AuthorizedParty,
@@ -23,7 +23,7 @@ internal class Constants
         JwtClaimTypes.ReferenceTokenId,
         JwtClaimTypes.SessionId,
         JwtClaimTypes.Scope
-    };
+    ];
 }
 
 internal static class RegistrationRequestParameters

--- a/src/Indice.Features.Identity.Core/DeviceAuthentication/Configuration/Constants.cs
+++ b/src/Indice.Features.Identity.Core/DeviceAuthentication/Configuration/Constants.cs
@@ -1,10 +1,12 @@
 ﻿using IdentityModel;
+using Indice.Features.Identity.Core.Data.Models;
 
 namespace Indice.Features.Identity.Core.DeviceAuthentication.Configuration;
 
 internal class Constants
 {
-    public static string DeviceAuthenticationOtpPurpose(string userId, string deviceId) => $"device-registration:{userId}:{deviceId}";
+    public static string DeviceAuthenticationOtpPurpose(string userId, string deviceId, InteractionMode interactionMode) => 
+        $"device-registration:{userId}:{deviceId}:{interactionMode}";
 
     public static readonly string[] ProtocolClaimsFilter = {
         JwtClaimTypes.AccessTokenHash,

--- a/src/Indice.Features.Identity.Core/DeviceAuthentication/Endpoints/InitRegistrationEndpoint.cs
+++ b/src/Indice.Features.Identity.Core/DeviceAuthentication/Endpoints/InitRegistrationEndpoint.cs
@@ -112,7 +112,7 @@ internal class InitRegistrationEndpoint : IEndpointHandler
                 .ToPrincipal(requestValidationResult?.Principal)
                 .WithMessage(IdentityMessageDescriber.DeviceRegistrationCodeMessage(existingDevice?.Name, requestValidationResult!.InteractionMode))
                 .UsingDeliveryChannel(requestValidationResult!.DeliveryChannel)
-                .WithPurpose(Constants.DeviceAuthenticationOtpPurpose(requestValidationResult!.UserId!, requestValidationResult!.DeviceId!))
+                .WithPurpose(Constants.DeviceAuthenticationOtpPurpose(requestValidationResult!.UserId!, requestValidationResult!.DeviceId!, requestValidationResult!.InteractionMode))
             );
             if (!totpResult.Success) {
                 return Error(totpResult.Error);

--- a/src/Indice.Features.Identity.Core/DeviceAuthentication/Stores/UserDeviceStoreEntityFrameworkCore.cs
+++ b/src/Indice.Features.Identity.Core/DeviceAuthentication/Stores/UserDeviceStoreEntityFrameworkCore.cs
@@ -43,6 +43,7 @@ public class UserDeviceStoreEntityFrameworkCore : IUserDeviceStore
     public async Task UpdatePassword(UserDevice? device, string? passwordHash) {
         ArgumentNullException.ThrowIfNull(nameof(device));
         device!.Password = passwordHash;
+        // TODO: Should add and use SecurityStamp for otp purpose in device authentication
         await _dbContext.SaveChangesAsync();
     }
 
@@ -50,6 +51,7 @@ public class UserDeviceStoreEntityFrameworkCore : IUserDeviceStore
     public async Task UpdatePublicKey(UserDevice? device, string? publicKey) {
         ArgumentNullException.ThrowIfNull(nameof(device));
         device!.PublicKey = publicKey;
+        // TODO: Should add and use SecurityStamp for otp purpose in device authentication
         await _dbContext.SaveChangesAsync();
     }
 

--- a/src/Indice.Features.Identity.Core/DeviceAuthentication/Validation/CompleteRegistrationRequestValidator.cs
+++ b/src/Indice.Features.Identity.Core/DeviceAuthentication/Validation/CompleteRegistrationRequestValidator.cs
@@ -140,7 +140,9 @@ internal class CompleteRegistrationRequestValidator : RequestValidatorBase<Compl
         }
         // Validate OTP code, if needed.
         if (DeviceAuthenticationOptions.AlwaysSendOtp || !mfaPassed) {
-            var totpResult = await TotpServiceFactory.Create<User>().VerifyAsync(user, parameters.Get(RegistrationRequestParameters.OtpCode)!, Constants.DeviceAuthenticationOtpPurpose(userId, authorizationCode.DeviceId!));
+            var totpResult = await TotpServiceFactory
+                .Create<User>()
+                .VerifyAsync(user, parameters.Get(RegistrationRequestParameters.OtpCode)!, Constants.DeviceAuthenticationOtpPurpose(userId, authorizationCode.DeviceId!, authorizationCode.InteractionMode));
             if (!totpResult.Success) {
                 return Error(totpResult.Error);
             }


### PR DESCRIPTION
We need to differentiate between the 4-pin and biometric purposes during device registration. 

Users completing the process in less than 30 seconds are encountering the error: `Last token has not expired yet. Please wait a few seconds and try again`.