### PR TITLE
Changes to GovGr models and scopes

### DIFF
--- a/src/Indice.Features.GovGr/GovGrKycScopeDescriber.cs
+++ b/src/Indice.Features.GovGr/GovGrKycScopeDescriber.cs
@@ -19,34 +19,46 @@ public class GovGrKycScopeDescriber
     public List<ScopeDescription> GetDescriptions(IStringLocalizer localizer = null) {
         var loc = localizer ?? _localizer;
         return new List<ScopeDescription> {
-             new ScopeDescription {
-                 Scope = GovGrKycScopes.ContactInfo,
-                 Description = loc["ContactInfoDescription"]
-             },
-             new ScopeDescription {
-                 Scope = GovGrKycScopes.Identity,
-                 Description = loc["IdentityDescription"]
-             },
-             new ScopeDescription {
-                 Scope = GovGrKycScopes.Income,
-                 Description = loc["IncomeDescription"]
-             },
-             new ScopeDescription {
-                 Scope = GovGrKycScopes.ProfessionalActivity,
-                 Description = loc["ProfessionalActivityDescription"]
-             },
-             new ScopeDescription {
-                 Scope = GovGrKycScopes.TaxIdInfo,
-                 Description = loc["TaxIdInfoDescription"]
-             },
-             new ScopeDescription {
-                 Scope = GovGrKycScopes.FamilyStatus,
-                 Description = loc["FamilyStatusDescription"]
-             },
             new ScopeDescription {
-                 Scope = GovGrKycScopes.Demographics,
-                 Description = loc["DemographicsDescription"]
-             },
+                Scope = GovGrKycScopes.ContactInfo,
+                Description = loc["ContactInfoDescription"]
+            },
+            new ScopeDescription {
+                Scope = GovGrKycScopes.Identity,
+                Description = loc["IdentityDescription"]
+            },
+            new ScopeDescription {
+                Scope = GovGrKycScopes.Income,
+                Description = loc["IncomeDescription"]
+            },
+            new ScopeDescription {
+                Scope = GovGrKycScopes.ProfessionalActivity,
+                Description = loc["ProfessionalActivityDescription"]
+            },
+            new ScopeDescription {
+                Scope = GovGrKycScopes.TaxIdInfo,
+                Description = loc["TaxIdInfoDescription"]
+            },
+            new ScopeDescription {
+                Scope = GovGrKycScopes.FamilyStatus,
+                Description = loc["FamilyStatusDescription"]
+            },
+            new ScopeDescription {
+                Scope = GovGrKycScopes.Demographics,
+                Description = loc["DemographicsDescription"]
+            },
+            new ScopeDescription {
+                Scope = GovGrKycScopes.ElectricitySupplyPoint,
+                Description = loc["ElectricitySupplyPointDescription"]
+            },
+            new ScopeDescription {
+                Scope = GovGrKycScopes.GasSupplyPoint,
+                Description = loc["GasSupplyPointDescription"]
+            },
+            new ScopeDescription {
+                Scope = GovGrKycScopes.IdentityBasic,
+                Description = loc["IdentityBasicDescription"]
+            }
         };
     }
 }

--- a/src/Indice.Features.GovGr/GovGrKycScopes.cs
+++ b/src/Indice.Features.GovGr/GovGrKycScopes.cs
@@ -5,16 +5,31 @@ public static class GovGrKycScopes
 {
     /// <summary>Access to Identity data</summary>
     public const string Identity = "identity";
+
     /// <summary>Access to Income data</summary>
     public const string Income = "income";
+
     /// <summary>Access to contact information</summary>
     public const string ContactInfo = "contactInfo";
+
     /// <summary>Access to Professional Activity </summary>
     public const string ProfessionalActivity = "professionalActivity";
+
     /// <summary>Access to Tax Information </summary>
     public const string TaxIdInfo = "taxidInfo";
+
     /// <summary>Access to Family Status </summary>
     public const string FamilyStatus = "familyStatus";
+
     /// <summary>Access to Demographic Data </summary>
     public const string Demographics = "demographics";
+
+    /// <summary>Access to Electricity Supply Data </summary>
+    public const string ElectricitySupplyPoint = "electricitySupplyPoint";
+
+    /// <summary>Access to Gas Supply Data </summary>
+    public const string GasSupplyPoint = "gasSupplyPoint";
+
+    /// <summary>Access to basic Identity Data </summary>
+    public const string IdentityBasic = "identityBasic";
 }

--- a/src/Indice.Features.GovGr/Models/KycModels.cs
+++ b/src/Indice.Features.GovGr/Models/KycModels.cs
@@ -155,8 +155,8 @@ public class KycPayload
         public string SurnameLatin { get; set; }
     }
 
-    /// <summary>GrcBo Data</summary>
-    public class GrcBoData
+    /// <summary>Δεδομένα Ταυτοποιητικού εγγράφου (grcBo, grcAo, etc.)</summary>
+    public class GrcData
     {
         /// <summary>Στοιχεία σχετικά με το έγγραφο επιβεβαίωσης</summary>
         [JsonPropertyName("documentInfo")]
@@ -169,9 +169,33 @@ public class KycPayload
     /// <summary>Identity Data</summary>
     public class IdentityData
     {
-        /// <summary>GrcBo</summary>
+        /// <summary>Ταυτότητες Ελλήνων Πολιτών</summary>
         [JsonPropertyName("grcBo")]
-        public KycDataWrapper<GrcBoData> GrcBo { get; set; }
+        public KycDataWrapper<GrcData> GrcBo { get; set; }
+
+        /// <summary>Ελληνικά Διαβατήρια</summary>
+        [JsonPropertyName("grcAo")]
+        public KycDataWrapper<GrcData> GrcAo { get; set; }
+
+        /// <summary>Υπηρεσιακά Δελτία Ταυτότητας Αστυνομικού Προσωπικού</summary>
+        [JsonPropertyName("grcBs")]
+        public KycDataWrapper<GrcData> GrcBs { get; set; }
+
+        /// <summary>Άδεια Διαμονής υπηκόων τρίτων χωρών</summary>
+        [JsonPropertyName("grcHo")]
+        public KycDataWrapper<GrcData> GrcHo { get; set; }
+
+        /// <summary>Ταξιδιωτικό έγγραφο χορηγούμενο σε αλλοδαπούς</summary>
+        [JsonPropertyName("grcJo")]
+        public KycDataWrapper<GrcData> GrcJo { get; set; }
+
+        /// <summary>Ταυτότητα Ομογενούς</summary>
+        [JsonPropertyName("grcPn")]
+        public KycDataWrapper<GrcData> GrcPn { get; set; }
+
+        /// <summary>Λοιπά εγχώρια ταυτοποιητικά έγγραφα</summary>
+        [JsonPropertyName("grc")]
+        public KycDataWrapper<GrcData> Grc {  get; set; }
     }
 
     /// <summary>Address</summary>
@@ -453,6 +477,38 @@ public class KycPayload
         public string Tin { get; set; }
     }
 
+    /// <summary>Unemployment Info Data</summary>
+    public class UnemploymentInfoData {
+        /// <summary>Επιδότηση Τακτικής Ανεργίας</summary>
+        [JsonPropertyName("repidot")]
+        public string Repidot { get; set; }
+
+        /// <summary>Ημέρες Επιδότησης κατά το τελευταίο έτος</summary>
+        [JsonPropertyName("rmonthsepidot")]
+        public string RMonthsEpidot { get; set; }
+    }
+
+    /// <summary>Pensioner Info Data</summary>
+    public class PensionerInfoData {
+        /// <summary>Ενεργή ιδιότητα συνταξιούχου</summary>
+        [JsonPropertyName("isPensioner")]
+        public bool IsPensioner { get; set; }
+    }
+
+    /// <summary>Academic Info Data</summary>
+    public class AcademicInfoData {
+        /// <summary>Tρέχουσες ενεργές ακαδημαϊκές ιδιότητες</summary>
+        [JsonPropertyName("academicProperties")]
+        public List<string> AcademicProperties { get; set; }
+    }
+
+    /// <summary>IEK Student Info Data</summary>
+    public class IekStudentInfo {
+        /// <summary>Στοιχεία φοίτησης σε ΙΕΚ</summary>
+        [JsonPropertyName("isActive")]
+        public bool IsActive { get; set; }
+    }
+
     /// <summary>Professional Activity Data</summary>
     public class ProfessionalActivityData
     {
@@ -465,6 +521,18 @@ public class KycPayload
         /// <summary>Self Employed Info</summary>
         [JsonPropertyName("selfEmployedInfo")]
         public KycDataWrapper<SelfEmployedInfoData> SelfEmployedInfo { get; set; }
+        /// <summary>Unemployment Info</summary>
+        [JsonPropertyName("unemploymentInfo")]
+        public KycDataWrapper<UnemploymentInfoData> UnemploymentInfo { get; set; }
+        /// <summary>Pensioner Info</summary>
+        [JsonPropertyName("pensionerInfo")]
+        public KycDataWrapper<PensionerInfoData> PensionerInfo { get; set; }
+        /// <summary>Academic Info</summary>
+        [JsonPropertyName("academicInfo")]
+        public KycDataWrapper<AcademicInfoData> AcademicInfo { get; set; }
+        /// <summary>IEK Student Info</summary>
+        [JsonPropertyName("iekStudentInfo")]
+        public KycDataWrapper<IekStudentInfo> IekStudentInfo { get; set; }
     }
 
     /// <summary> Tax Information Data </summary>

--- a/src/Indice.Features.GovGr/Resources/GovGrKycScopeDescriber.el.resx
+++ b/src/Indice.Features.GovGr/Resources/GovGrKycScopeDescriber.el.resx
@@ -123,9 +123,6 @@
   <data name="DemographicsDescription" xml:space="preserve">
     <value>Δημογραφικά Στοιχεία</value>
   </data>
-  <data name="FamilyStatusDescription" xml:space="preserve">
-    <value>Στοιχεία Οικογενειακής Κατάστασης</value>
-  </data>
   <data name="IdentityDescription" xml:space="preserve">
     <value>Στοιχεία Ταυτότητας</value>
   </data>
@@ -137,5 +134,12 @@
   </data>
   <data name="TaxIdInfoDescription" xml:space="preserve">
     <value>Στοιχεία ΔΟΥ</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="IdentityBasicDescription" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="ElectricitySupplyPointDescription" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
   </data>
 </root>

--- a/src/Indice.Features.GovGr/Resources/GovGrKycScopeDescriber.en.resx
+++ b/src/Indice.Features.GovGr/Resources/GovGrKycScopeDescriber.en.resx
@@ -123,9 +123,6 @@
   <data name="DemographicsDescription" xml:space="preserve">
     <value>Demographics Information</value>
   </data>
-  <data name="FamilyStatusDescription" xml:space="preserve">
-    <value>Family Status Information</value>
-  </data>
   <data name="IdentityDescription" xml:space="preserve">
     <value>Identity Information</value>
   </data>
@@ -137,5 +134,12 @@
   </data>
   <data name="TaxIdInfoDescription" xml:space="preserve">
     <value>Tax Information</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="IdentityBasicDescription" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="ElectricitySupplyPointDescription" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
   </data>
 </root>

--- a/src/Indice.Features.GovGr/Resources/GovGrKycScopeDescriber.resx
+++ b/src/Indice.Features.GovGr/Resources/GovGrKycScopeDescriber.resx
@@ -123,11 +123,8 @@
   <data name="DemographicsDescription" xml:space="preserve">
     <value>Δημογραφικά Στοιχεία</value>
   </data>
-  <data name="FamilyStatusDescription" xml:space="preserve">
-    <value>Στοιχεία Οικογενειακής Κατάστασης</value>
-  </data>
   <data name="IdentityDescription" xml:space="preserve">
-    <value>Στοιχεία Ταυτότητας</value>
+    <value>Στοιχεία Ταυτότητας (Πλήρη στοιχεία)</value>
   </data>
   <data name="IncomeDescription" xml:space="preserve">
     <value>Στοιχεία Εισοδήματος</value>
@@ -136,6 +133,18 @@
     <value>Στοιχεία Επαγγελματικής Δραστηριότητας</value>
   </data>
   <data name="TaxIdInfoDescription" xml:space="preserve">
-    <value>Στοιχεία ΔΟΥ</value>
+    <value>Στοιχεία φορολογικού μητρώου</value>
+  </data>
+  <data name="IdentityBasicDescription" xml:space="preserve">
+    <value>Στοιχεία ταυτότητας (Βασικά στοιχεία)</value>
+  </data>
+  <data name="ElectricitySupplyPointDescription" xml:space="preserve">
+    <value>Στοιχεία Παροχής Ηλεκτροδότησης</value>
+  </data>
+  <data name="GasSupplyPointDescription" xml:space="preserve">
+    <value>Στοιχεία Παροχής Φυσικού Αερίου</value>
+  </data>
+  <data name="FamilyStatusDescription" xml:space="preserve">
+    <value>Στοιχεία Οικογενειακής Κατάστασης</value>
   </data>
 </root>


### PR DESCRIPTION
 New GovGR changes:

- Three new scopes added: `ElectricitySupplyPoint, GasSupplyPoint and IdentityBasic`
- New models added: `unemploymentInfo, pensionerInfo, academicInfo, iekStudentInfo`
- `FamilyStatus` scope to be removed