### PR TITLE
[Core] Allow EndpointFilterInvocationContext to be passed in ValidationFilter.cs handled exceptions

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
       <Copyright>Copyright (c) 2018 Indice</Copyright>
       <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
       <VersionPrefixBase>7.32</VersionPrefixBase>
-      <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
+      <VersionPrefixCore>$(VersionPrefixBase).1</VersionPrefixCore>
       <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
       <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
       <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>

--- a/src/Indice.AspNetCore/Http/Filters/ValidationFilter.cs
+++ b/src/Indice.AspNetCore/Http/Filters/ValidationFilter.cs
@@ -116,7 +116,7 @@ public static partial class ValidationFilterExtensions
 
     /// <summary>Adds exception handling for the specified exception.</summary>
     /// <typeparam name="TException"></typeparam>
-    /// <param name="builder">A builder for defining single endpoint.</param>
+    /// <param name="builder">A builder for defining a single endpoint.</param>
     /// <param name="statusCode">The HTTP status code.</param>
     /// <param name="exceptionHandler">The action to perform when the exception occurs. Can be left null for default implementation. This takes precedence over <see cref="exceptionHandlerWithContext"/>.</param>
     /// <param name="exceptionHandlerWithContext">The action to perform when the exception occurs. This also passes the <see cref="EndpointFilterInvocationContext"/> on invocation. Can be left null for default implementation.</param>
@@ -131,8 +131,8 @@ public static partial class ValidationFilterExtensions
     /// <summary>
     /// Adds the validation of input parameters and <see cref="HttpValidationProblemDetails"/> automatic response when something is out of place.
     /// If multiple filters are specified for a type of <see cref="TException"/> order is:
-    /// Code Before `next` --> FIFO
-    /// Code After `next` --> FILO
+    /// Code Before `next()` method call --> FIFO
+    /// Code After `next()` method call --> FILO
     /// </summary>
     /// <typeparam name="TBuilder"></typeparam>
     /// <typeparam name="TException"></typeparam>


### PR DESCRIPTION
@dkarkanas 
Why:
Wanted to use request specific information for creating ProblemDetails.

Comments: 
1. Passing invocation context on an Exception handler is a good idea imo, there are no extra method calls. We can fully customize the IResult based on the request.
2. It is done in non breaking way.
3. The way it is done we will `carry` this duplication forever. If we want, we can copy paste and mark current 3 methods as obsolete.
4. Not sure about the versioning stuff, I just bumped up the `VersionPrefixCore`

Commits SHOULD be squashed if merged.