### PR TITLE
Add option for controlling AllowedFileSizeAttribute file size limit

### DIFF
--- a/src/Indice.AspNetCore/Filters/AllowedFileSizeAttribute.cs
+++ b/src/Indice.AspNetCore/Filters/AllowedFileSizeAttribute.cs
@@ -21,7 +21,7 @@ public class AllowedFileSizeAttribute : Attribute, IActionFilter
 
     /// <inheritdoc />
     public void OnActionExecuting(ActionExecutingContext context) {
-        long sizeLimit = _defaultSizeLimit;
+        var sizeLimit = _defaultSizeLimit;
 
         if (!string.IsNullOrWhiteSpace(_configurationKey)) {
             var configuration = context.HttpContext.RequestServices.GetService<IConfiguration>();

--- a/src/Indice.AspNetCore/Filters/AllowedFileSizeAttribute.cs
+++ b/src/Indice.AspNetCore/Filters/AllowedFileSizeAttribute.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Indice.AspNetCore.Filters;
 
@@ -8,20 +10,28 @@ namespace Indice.AspNetCore.Filters;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public class AllowedFileSizeAttribute : Attribute, IActionFilter
 {
-    private readonly long _sizeLimit;
+    private long _defaultSizeLimit;
+    private readonly string _configurationKey;
 
     /// <summary>Creates a new instance of <see cref="AllowedFileSizeAttribute"/>.</summary>
-    /// <param name="sizeLimit">The maximum allowed file size in bytes.</param>
-    public AllowedFileSizeAttribute(long sizeLimit) {
-        _sizeLimit = sizeLimit;
+    public AllowedFileSizeAttribute(long defaultSizeLimit, string configurationKey = null) {
+        _configurationKey = configurationKey;
+        _defaultSizeLimit = defaultSizeLimit;
     }
 
     /// <inheritdoc />
     public void OnActionExecuting(ActionExecutingContext context) {
+        long sizeLimit = _defaultSizeLimit;
+
+        if (!string.IsNullOrWhiteSpace(_configurationKey)) {
+            var configuration = context.HttpContext.RequestServices.GetService<IConfiguration>();
+            sizeLimit = configuration?.GetValue(_configurationKey, _defaultSizeLimit) ?? _defaultSizeLimit;
+        }
+
         IEnumerable<IFormFile> files = context.HttpContext.Request.Form.Files;
         foreach (var file in files) {
-            if (file.Length > _sizeLimit) {
-                context.ModelState.AddModelError($"{file.FileName}", $"File size cannot exceed {_sizeLimit} bytes.");
+            if (file.Length > sizeLimit) {
+                context.ModelState.AddModelError($"{file.FileName}", $"File size cannot exceed {sizeLimit} bytes.");
                 context.Result = new BadRequestObjectResult(context.ModelState);
             }
         }

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiConstants.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiConstants.cs
@@ -36,6 +36,9 @@ public static class CasesApiConstants
     /// <summary>The default permitted file extensions to check when uploading an attachment to an existing case.</summary>
     public static IReadOnlyCollection<string> DefaultPermittedAttachmentFileExtensions = new HashSet<string> { ".pdf", ".jpeg", ".jpg", ".tif", ".tiff" };
 
+    /// <summary>The default file size limit in request body (6 megabytes).</summary>
+    public const long ALLOWED_FILE_SIZE_BYTES_DEFAULT = 6291456;
+
     /// <summary>Cases API policies.</summary>
     public static class Policies
     {

--- a/src/Indice.Features.Cases.AspNetCore/CasesApiOptions.cs
+++ b/src/Indice.Features.Cases.AspNetCore/CasesApiOptions.cs
@@ -35,6 +35,9 @@ public abstract class CasesApiOptions
 
     /// <summary>Specifies the permitted file extensions to check when uploading an attachment to an existing case.</summary>
     public IReadOnlyCollection<string> PermittedAttachmentFileExtensions { get; set; } = CasesApiConstants.DefaultPermittedAttachmentFileExtensions;
+
+    /// <summary>The file size limit in request body.</summary>
+    public long AllowedFileSizeBytes { get; set; } = CasesApiConstants.ALLOWED_FILE_SIZE_BYTES_DEFAULT;
 }
 
 /// <summary>

--- a/src/Indice.Features.Cases.AspNetCore/Controllers/AdminCasesController.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Controllers/AdminCasesController.cs
@@ -75,7 +75,7 @@ internal class AdminCasesController : ControllerBase
     /// <param name="caseId">The Id of the case.</param>
     /// <param name="file">The file to attach.</param>
     /// <returns></returns>
-    [AllowedFileSize(6291456)] // 6 MegaBytes
+    [AllowedFileSize(CasesApiConstants.ALLOWED_FILE_SIZE_BYTES_DEFAULT, $"{nameof(CasesApiOptions)}:{nameof(CasesApiOptions.AllowedFileSizeBytes)}")] // 6 MegaBytes
     [Consumes("multipart/form-data")]
     [DisableRequestSizeLimit]
     [HttpPost("{caseId:guid}/attachments")]

--- a/src/Indice.Features.Cases.AspNetCore/Controllers/MyCasesController.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Controllers/MyCasesController.cs
@@ -82,7 +82,7 @@ internal class MyCasesController : ControllerBase
     /// <param name="caseId">The Id of the case.</param>
     /// <param name="file">The file to attach.</param>
     /// <returns></returns>
-    [AllowedFileSize(6291456)] // 6 MegaBytes
+    [AllowedFileSize(CasesApiConstants.ALLOWED_FILE_SIZE_BYTES_DEFAULT, $"{nameof(CasesApiOptions)}:{nameof(CasesApiOptions.AllowedFileSizeBytes)}")] // 6 MegaBytes
     [Consumes("multipart/form-data")]
     [DisableRequestSizeLimit]
     [HttpPost("{caseId:guid}/attachments")]


### PR DESCRIPTION
Modify the `AllowedFileSizeAttribute` to allow overriding the file size limit, by providing an optional configuration key name.