### PR TITLE
Bugfix for expired trusted browser

### DIFF
--- a/src/Indice.AspNetCore.Identity/Services/AccountService.cs
+++ b/src/Indice.AspNetCore.Identity/Services/AccountService.cs
@@ -122,7 +122,7 @@ public class AccountService(
         var isExistingBrowser = false;
         if (!string.IsNullOrWhiteSpace(deviceIdentifier.Value)) {
             var browserDevice = await _userManager.GetDeviceByIdAsync(user, deviceIdentifier.Value);
-            isExistingBrowser = browserDevice is not null;
+            isExistingBrowser = browserDevice is not null && browserDevice.MfaSessionExpirationDate > DateTimeOffset.UtcNow;
         }
         return new MfaLoginViewModel {
             AllowMfaChannelDowngrade = allowMfaChannelDowngrade,


### PR DESCRIPTION
`IsExistingBrowser` should be false if the current browser's identifier is expired, by date-comparing using `MfaSessionExpirationDate`.