### PR TITLE
GetAttachmentByField parsing fix

### DIFF
--- a/src/Indice.Features.Cases.AspNetCore/Services/AdminCaseService.cs
+++ b/src/Indice.Features.Cases.AspNetCore/Services/AdminCaseService.cs
@@ -470,7 +470,7 @@ internal class AdminCaseService : BaseCaseService, IAdminCaseService
         var stringifiedCaseData = (await GetCaseById(user, caseId, false)).DataAs<string>();
         var json = JsonDocument.Parse(stringifiedCaseData);
         bool found = json.RootElement.TryGetProperty(fieldName, out JsonElement attachmentId);
-        if (found) {
+        if (found && !string.IsNullOrEmpty(attachmentId.GetString())) {
             var attachment = await GetAttachment(caseId, attachmentId.GetGuid());
             return attachment;
         }


### PR DESCRIPTION
Calling GetAttachmentByField while a property is filled with an empty string will no longer be problematic. You can safely reset fields by setting them to an empty string.