### PR TITLE
[identity] Adjust reveal icon positioning in CSS

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
 
     <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
     <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
     <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
     <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>

--- a/src/Indice.Features.Identity.UI/wwwroot/css/_reveal.scss
+++ b/src/Indice.Features.Identity.UI/wwwroot/css/_reveal.scss
@@ -15,7 +15,7 @@ input[type="password"]::-ms-clear {
     right: 0;
     bottom: 0;
     display: block;
-    transform: translate(-200%, -50%);
+    transform: translate(-50%, -50%);
 }
 
     .reveal-icon::before {
@@ -32,7 +32,7 @@ input[type="password"]::-ms-clear {
         background-image: url('../img/reveal.svg');
     }
 .extra-icon .reveal-icon {
-    transform: translate(-50%, 100%);
+    transform: translate(-200%, -50%);
 }
 
 input.password[type="text"] + .reveal-icon::before,

--- a/src/Indice.Features.Identity.UI/wwwroot/css/identity.css
+++ b/src/Indice.Features.Identity.UI/wwwroot/css/identity.css
@@ -1203,7 +1203,7 @@ input[type=password]::-ms-clear {
   background-image: url("../img/reveal.svg");
 }
 .extra-icon .reveal-icon {
-  transform: translate(-50%, 100%);
+  transform: translate(-200%, -50%);
 }
 input.password[type=text] + .reveal-icon::before,
 input.password[type=text] ~ .reveal-icon::before {

--- a/src/Indice.Features.Identity.UI/wwwroot/css/identity.tw.css
+++ b/src/Indice.Features.Identity.UI/wwwroot/css/identity.tw.css
@@ -1059,7 +1059,7 @@ input[type=password]::-ms-clear {
 }
 
 .extra-icon .reveal-icon {
-  transform: translate(-50%, 100%);
+  transform: translate(-200%, -50%);
 }
 
 input.password[type=text] + .reveal-icon::before,


### PR DESCRIPTION
Updated transform properties for .reveal-icon and input[type="password"]::-ms-clear across multiple stylesheets to improve alignment and appearance of password field icons.