### PR TITLE
[identity] ResetPassword event: Discriminate between `Self` & `Admin` initiated resets

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,8 +8,8 @@
     <VersionPrefixBase>$(VersionPrefixMajor).54</VersionPrefixBase>
 
     <VersionPrefixCore>$(VersionPrefixBase).0</VersionPrefixCore>
-    <VersionPrefixIdentity>$(VersionPrefixBase).0</VersionPrefixIdentity>
-    <VersionPrefixIdentityUI>$(VersionPrefixBase).0</VersionPrefixIdentityUI>
+    <VersionPrefixIdentity>$(VersionPrefixBase).1</VersionPrefixIdentity>
+    <VersionPrefixIdentityUI>$(VersionPrefixBase).1</VersionPrefixIdentityUI>
     <VersionPrefixCases>$(VersionPrefixBase).0</VersionPrefixCases>
     <VersionPrefixMessages>$(VersionPrefixBase).0</VersionPrefixMessages>
     <VersionPrefixMultitenancy>$(VersionPrefixBase).0</VersionPrefixMultitenancy>

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -293,10 +293,10 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
     /// <param name="newPassword">The new password.</param>
     /// <param name="validatePassword">Whether to validate the password.</param>
     /// <param name="suppressNotification">Whether to suppress the security notification triggered after an administrator password reset.</param>
-    /// <param name="isSelfServiceReset"> Whether the reset was executed by the user themselves</param>
+    /// <param name="selfServicePasswordReset"> Whether the reset was executed by the user themselves</param>
     /// <returns>Whether the password was successfully updated.</returns>
     /// <remarks>This overload is used for administrator reset password. Bypasses token requirement of default <see cref="UserManager{TUser}.ResetPasswordAsync(TUser, string, string)"/></remarks>
-    public async Task<IdentityResult> ResetPasswordAsync(TUser user, string newPassword, bool validatePassword = true, bool suppressNotification = false, bool isSelfServiceReset = true) {
+    public async Task<IdentityResult> ResetPasswordAsync(TUser user, string newPassword, bool validatePassword = true, bool suppressNotification = false, bool selfServicePasswordReset = true) {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(user);
         var result = await base.UpdatePasswordHash(user, newPassword, validatePassword);
@@ -310,7 +310,7 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
         if (await IsLockedOutAsync(user)) {
             result = await SetLockoutEndDateAsync(user, null);
         }
-        if (isSelfServiceReset) {
+        if (selfServicePasswordReset) {
             await _eventService.Publish(new PasswordChangedEvent(UserEventContext.InitializeFromUser(user)));
         } else {
             await _eventService.Publish(new PasswordSetEvent(UserEventContext.InitializeFromUser(user), suppressNotification));

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -293,10 +293,10 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
     /// <param name="newPassword">The new password.</param>
     /// <param name="validatePassword">Whether to validate the password.</param>
     /// <param name="suppressNotification">Whether to suppress the security notification triggered after an administrator password reset.</param>
-    /// <param name="isAdminOperation">Whether the reset was executed by an administrator.</param>
+    /// <param name="isSelfServiceReset"> Whether the reset was executed by the user themselves</param>
     /// <returns>Whether the password was successfully updated.</returns>
     /// <remarks>This overload is used for administrator reset password. Bypasses token requirement of default <see cref="UserManager{TUser}.ResetPasswordAsync(TUser, string, string)"/></remarks>
-    public async Task<IdentityResult> ResetPasswordAsync(TUser user, string newPassword, bool validatePassword = true, bool suppressNotification = false, bool isAdminOperation = false) {
+    public async Task<IdentityResult> ResetPasswordAsync(TUser user, string newPassword, bool validatePassword = true, bool suppressNotification = false, bool isSelfServiceReset = true) {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(user);
         var result = await base.UpdatePasswordHash(user, newPassword, validatePassword);
@@ -310,10 +310,10 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
         if (await IsLockedOutAsync(user)) {
             result = await SetLockoutEndDateAsync(user, null);
         }
-        if (isAdminOperation) {
-            await _eventService.Publish(new PasswordSetEvent(UserEventContext.InitializeFromUser(user), suppressNotification));
-        } else {
+        if (isSelfServiceReset) {
             await _eventService.Publish(new PasswordChangedEvent(UserEventContext.InitializeFromUser(user)));
+        } else {
+            await _eventService.Publish(new PasswordSetEvent(UserEventContext.InitializeFromUser(user), suppressNotification));
         }
         return result;
     }

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -293,9 +293,10 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
     /// <param name="newPassword">The new password.</param>
     /// <param name="validatePassword">Whether to validate the password.</param>
     /// <param name="suppressNotification">Whether to suppress the security notification triggered after an administrator password reset.</param>
+    /// <param name="isAdminOperation"> Whether the re reset executed bu administrator or not.</param>
     /// <returns>Whether the password was successfully updated.</returns>
     /// <remarks>This overload is used for administrator reset password. Bypasses token requirement of default <see cref="UserManager{TUser}.ResetPasswordAsync(TUser, string, string)"/></remarks>
-    public async Task<IdentityResult> ResetPasswordAsync(TUser user, string newPassword, bool validatePassword = true, bool suppressNotification = false) {
+    public async Task<IdentityResult> ResetPasswordAsync(TUser user, string newPassword, bool validatePassword = true, bool suppressNotification = false, bool isAdminOperation = false) {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(user);
         var result = await base.UpdatePasswordHash(user, newPassword, validatePassword);
@@ -309,7 +310,11 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
         if (await IsLockedOutAsync(user)) {
             result = await SetLockoutEndDateAsync(user, null);
         }
-        await _eventService.Publish(new PasswordSetEvent(UserEventContext.InitializeFromUser(user), suppressNotification));
+        if (isAdminOperation) {
+            await _eventService.Publish(new PasswordSetEvent(UserEventContext.InitializeFromUser(user), suppressNotification));
+        } else {
+            await _eventService.Publish(new PasswordChangedEvent(UserEventContext.InitializeFromUser(user)));
+        }
         return result;
     }
 

--- a/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
+++ b/src/Indice.Features.Identity.Core/ExtendedUserManager.cs
@@ -293,7 +293,7 @@ public partial class ExtendedUserManager<TUser> : UserManager<TUser> where TUser
     /// <param name="newPassword">The new password.</param>
     /// <param name="validatePassword">Whether to validate the password.</param>
     /// <param name="suppressNotification">Whether to suppress the security notification triggered after an administrator password reset.</param>
-    /// <param name="isAdminOperation"> Whether the re reset executed bu administrator or not.</param>
+    /// <param name="isAdminOperation">Whether the reset was executed by an administrator.</param>
     /// <returns>Whether the password was successfully updated.</returns>
     /// <remarks>This overload is used for administrator reset password. Bypasses token requirement of default <see cref="UserManager{TUser}.ResetPasswordAsync(TUser, string, string)"/></remarks>
     public async Task<IdentityResult> ResetPasswordAsync(TUser user, string newPassword, bool validatePassword = true, bool suppressNotification = false, bool isAdminOperation = false) {

--- a/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
@@ -731,7 +731,7 @@ internal static class UserHandlers
         if (user == null) {
             return TypedResults.NotFound();
         }
-        var result = await userManager.ResetPasswordAsync(user, request.Password!, validatePassword: !request.BypassPasswordValidation.GetValueOrDefault(), suppressNotification: request.SuppressNotification.GetValueOrDefault());
+        var result = await userManager.ResetPasswordAsync(user, request.Password!, validatePassword: !request.BypassPasswordValidation.GetValueOrDefault(), suppressNotification: request.SuppressNotification.GetValueOrDefault(), true);
         if (!result.Succeeded) {
             return TypedResults.ValidationProblem(result.Errors.ToDictionary());
         }

--- a/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
@@ -731,7 +731,7 @@ internal static class UserHandlers
         if (user == null) {
             return TypedResults.NotFound();
         }
-        var result = await userManager.ResetPasswordAsync(user, request.Password!, validatePassword: !request.BypassPasswordValidation.GetValueOrDefault(), suppressNotification: request.SuppressNotification.GetValueOrDefault(), isAdminOperation: true);
+        var result = await userManager.ResetPasswordAsync(user, request.Password!, validatePassword: !request.BypassPasswordValidation.GetValueOrDefault(), suppressNotification: request.SuppressNotification.GetValueOrDefault(), isSelfServiceReset: false);
         if (!result.Succeeded) {
             return TypedResults.ValidationProblem(result.Errors.ToDictionary());
         }

--- a/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
@@ -731,7 +731,7 @@ internal static class UserHandlers
         if (user == null) {
             return TypedResults.NotFound();
         }
-        var result = await userManager.ResetPasswordAsync(user, request.Password!, validatePassword: !request.BypassPasswordValidation.GetValueOrDefault(), suppressNotification: request.SuppressNotification.GetValueOrDefault(), true);
+        var result = await userManager.ResetPasswordAsync(user, request.Password!, validatePassword: !request.BypassPasswordValidation.GetValueOrDefault(), suppressNotification: request.SuppressNotification.GetValueOrDefault(), isAdminOperation: true);
         if (!result.Succeeded) {
             return TypedResults.ValidationProblem(result.Errors.ToDictionary());
         }

--- a/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
+++ b/src/Indice.Features.Identity.Server/Manager/UserHandlers.cs
@@ -731,7 +731,7 @@ internal static class UserHandlers
         if (user == null) {
             return TypedResults.NotFound();
         }
-        var result = await userManager.ResetPasswordAsync(user, request.Password!, validatePassword: !request.BypassPasswordValidation.GetValueOrDefault(), suppressNotification: request.SuppressNotification.GetValueOrDefault(), isSelfServiceReset: false);
+        var result = await userManager.ResetPasswordAsync(user, request.Password!, validatePassword: !request.BypassPasswordValidation.GetValueOrDefault(), suppressNotification: request.SuppressNotification.GetValueOrDefault(), selfServicePasswordReset: false);
         if (!result.Succeeded) {
             return TypedResults.ValidationProblem(result.Errors.ToDictionary());
         }

--- a/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
+++ b/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
@@ -65,7 +65,7 @@ public abstract class BasePasswordExpiredModel : BasePageModel
             return Page();
         }
         var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
-        var result = await UserManager.ResetPasswordAsync(user, Input.NewPassword!, isSelfServiceReset: true);
+        var result = await UserManager.ResetPasswordAsync(user, Input.NewPassword!, selfServicePasswordReset: true);
         if (!result.Succeeded) {
             AddModelErrors(result);
             return Page();

--- a/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
+++ b/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
@@ -65,7 +65,7 @@ public abstract class BasePasswordExpiredModel : BasePageModel
             return Page();
         }
         var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
-        var result = await UserManager.ResetPasswordAsync(user, Input.NewPassword!, isAdminOperation: false);
+        var result = await UserManager.ResetPasswordAsync(user, Input.NewPassword!, isSelfServiceReset: true);
         if (!result.Succeeded) {
             AddModelErrors(result);
             return Page();

--- a/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
+++ b/src/Indice.Features.Identity.UI/Pages/PasswordExpired.cs
@@ -65,7 +65,7 @@ public abstract class BasePasswordExpiredModel : BasePageModel
             return Page();
         }
         var user = await UserManager.GetUserAsync(User) ?? throw new InvalidOperationException("User cannot be null.");
-        var result = await UserManager.ResetPasswordAsync(user, Input.NewPassword!);
+        var result = await UserManager.ResetPasswordAsync(user, Input.NewPassword!, isAdminOperation: false);
         if (!result.Succeeded) {
             AddModelErrors(result);
             return Page();


### PR DESCRIPTION
Updated `Directory.Build.props` to increment version values. Enhanced `ResetPasswordAsync` in `ExtendedUserManager<TUser>` to include `isAdminOperation` for admin/non-admin resets. Adjusted event publishing logic based on `isAdminOperation`. Updated `UserHandlers` and `BasePasswordExpiredModel` to pass appropriate `isAdminOperation` values.