### PR TITLE
[agents] UI Add support for rendering HTML fragments in chat

### DIFF
--- a/src/Indice.Features.Agents.App/src/app/features/chat/chat-message-part.component.ts
+++ b/src/Indice.Features.Agents.App/src/app/features/chat/chat-message-part.component.ts
@@ -46,7 +46,7 @@ import { parseCallout, parseConfirmation, parseImage, parseMultipleChoice, partK
         ></div>
       }
       @case ('html') {
-        <app-chat-html [html]="part().value" [first]="first()" [caret]="caret()" />
+        <app-chat-html [html]="part().value" [caption]="part().name" [first]="first()" [caret]="caret()" />
       }
       @case ('image') {
         <app-chat-image [image]="image()" />

--- a/src/Indice.Features.Agents.App/src/app/features/chat/chat-message-part.component.ts
+++ b/src/Indice.Features.Agents.App/src/app/features/chat/chat-message-part.component.ts
@@ -4,6 +4,7 @@ import { MarkdownModule } from 'ngx-markdown';
 import { IChatMessagePart } from '../../core/services/dex-api.service';
 import { ChatCalloutComponent } from './parts/chat-callout.component';
 import { ChatConfirmComponent } from './parts/chat-confirm.component';
+import { ChatHtmlComponent } from './parts/chat-html.component';
 import { ChatImageComponent } from './parts/chat-image.component';
 import { ChatOptionsComponent } from './parts/chat-options.component';
 import { parseCallout, parseConfirmation, parseImage, parseMultipleChoice, partKind } from './parts/part-contracts';
@@ -24,7 +25,14 @@ import { parseCallout, parseConfirmation, parseImage, parseMultipleChoice, partK
   selector: 'app-chat-message-part',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'contents' },
-  imports: [MarkdownModule, ChatCalloutComponent, ChatConfirmComponent, ChatImageComponent, ChatOptionsComponent],
+  imports: [
+    MarkdownModule,
+    ChatCalloutComponent,
+    ChatConfirmComponent,
+    ChatHtmlComponent,
+    ChatImageComponent,
+    ChatOptionsComponent,
+  ],
   template: `
     @switch (kind()) {
       @case ('markdown') {
@@ -36,6 +44,9 @@ import { parseCallout, parseConfirmation, parseImage, parseMultipleChoice, partK
           markdown
           [data]="part().value"
         ></div>
+      }
+      @case ('html') {
+        <app-chat-html [html]="part().value" [first]="first()" [caret]="caret()" />
       }
       @case ('image') {
         <app-chat-image [image]="image()" />

--- a/src/Indice.Features.Agents.App/src/app/features/chat/parts/chat-html.component.ts
+++ b/src/Indice.Features.Agents.App/src/app/features/chat/parts/chat-html.component.ts
@@ -1,0 +1,104 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation, computed, input } from '@angular/core';
+
+/**
+ * Renders a `text/html` part as prose inside the same bordered bubble the markdown case uses, so an HTML fragment and
+ * a markdown one sit indistinguishably in the thread.
+ *
+ * The fragment may arrive in three shapes: a plain HTML string, or a `data:text/html` URI in either its base64 or its
+ * percent-encoded form. All three decode to the same markup before rendering; a data URI that fails to decode renders
+ * nothing rather than spilling an opaque base64 blob into the thread.
+ *
+ * The fragment is bound through `[innerHTML]`, which routes it through Angular's built-in sanitizer: scripts, event
+ * handlers, and other active content are stripped before the markup reaches the DOM. That is a deliberate choice over
+ * `bypassSecurityTrustHtml` — the fragment usually originates from a model or an external document, so it is never
+ * trusted wholesale.
+ *
+ * An empty or whitespace-only fragment renders nothing at all, costing no gap in the part stack — the same discipline
+ * the other part renderers apply to payloads with nothing to show.
+ */
+@Component({
+  selector: 'app-chat-html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  styles: `
+    .dex-html { line-height: 1.55; }
+    .dex-html section, .dex-html article { padding: 0.25rem 0; }
+    .dex-html h1, .dex-html h2, .dex-html h3, .dex-html h4 {
+      margin: 0.75rem 0 0.25rem; font-weight: 600; line-height: 1.3;
+    }
+    .dex-html h3 { font-size: 1.05rem; }
+    .dex-html p { margin: 0.375rem 0; }
+    .dex-html ul { margin: 0.5rem 0; padding-left: 0; list-style: none; }
+    .dex-html li { margin: 0.375rem 0; }
+    .dex-html a { color: var(--color-primary); text-decoration: none; }
+    .dex-html a:hover { text-decoration: underline; }
+    .dex-html img { border-radius: 0.75rem; }
+    .dex-html figure { margin: 0; }
+    .dex-html .dex-card {
+      display: flex; gap: 1rem; align-items: flex-start;
+      padding: 1rem; margin: 0.25rem 0;
+      border: 1px solid var(--color-base-300); border-radius: 1rem;
+      background: var(--color-base-100);
+    }
+    .dex-html .dex-card img {
+      width: 5rem; height: 5rem; border-radius: 9999px; object-fit: cover; flex: none;
+      outline: 2px solid var(--color-primary); outline-offset: 2px;
+    }
+    .dex-html .dex-muted { color: color-mix(in oklch, var(--color-base-content) 60%, transparent); font-size: 0.85em; }
+    .dex-html .dex-badge {
+      display: inline-block; padding: 0.125rem 0.625rem; border-radius: 9999px;
+      font-size: 0.75rem; font-weight: 500;
+      background: color-mix(in oklch, var(--color-primary) 12%, transparent);
+      color: var(--color-primary);
+    }
+  `,
+  template: `
+    @if (content(); as fragment) {
+      <div
+        class="dex-html text-[0.95rem]"
+        [class.rounded-tl-sm]="first()"
+        [class.dex-caret]="caret()"
+        [innerHTML]="fragment"
+      ></div>
+    }
+  `,
+})
+export class ChatHtmlComponent {
+  /** The HTML fragment to render, or null when the part carried nothing renderable. */
+  readonly html = input<string | null | undefined>(null);
+  /** Whether this is the message's first part; only that one gets the bubble tail pointing at the avatar. */
+  readonly first = input(false);
+  /** Whether to show the blinking streaming caret. */
+  readonly caret = input(false);
+
+  protected readonly content = computed(() => decodeHtmlFragment(this.html()));
+}
+
+/** Matches a `data:text/html[;charset=...][;base64],payload` URI, capturing the parameter list and the payload. */
+const DATA_URI_PATTERN = /^data:text\/html([^,]*),([\s\S]*)$/i;
+
+/**
+ * Normalizes a `text/html` part value to the markup it carries. A plain string passes through trimmed; a
+ * `data:text/html` URI is decoded from base64 (UTF-8) or percent-encoding as its parameters dictate. Anything
+ * empty or undecodable yields `null`, which the template treats as "nothing to show".
+ */
+function decodeHtmlFragment(value: string | null | undefined): string | null {
+  const raw = value?.trim();
+  if (!raw) {
+    return null;
+  }
+  const match = DATA_URI_PATTERN.exec(raw);
+  if (!match) {
+    return raw;
+  }
+  const [, params, payload] = match;
+  try {
+    const decoded = /;base64/i.test(params)
+      ? new TextDecoder().decode(Uint8Array.from(atob(payload), (char) => char.charCodeAt(0)))
+      : decodeURIComponent(payload);
+    const fragment = decoded.trim();
+    return fragment ? fragment : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/Indice.Features.Agents.App/src/app/features/chat/parts/chat-html.component.ts
+++ b/src/Indice.Features.Agents.App/src/app/features/chat/parts/chat-html.component.ts
@@ -1,8 +1,7 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation, computed, input } from '@angular/core';
 
 /**
- * Renders a `text/html` part as prose inside the same bordered bubble the markdown case uses, so an HTML fragment and
- * a markdown one sit indistinguishably in the thread.
+ * Renders a `text/html` part dex-html fragment in the chat thread.
  *
  * The fragment may arrive in three shapes: a plain HTML string, or a `data:text/html` URI in either its base64 or its
  * percent-encoded form. All three decode to the same markup before rendering; a data URI that fails to decode renders
@@ -79,7 +78,7 @@ const DATA_URI_PATTERN = /^data:text\/html([^,]*),([\s\S]*)$/i;
 
 /**
  * Normalizes a `text/html` part value to the markup it carries. A plain string passes through trimmed; a
- * `data:text/html` URI is decoded from base64 (UTF-8) or percent-encoding as its parameters dictate. Anything
+ * `data:text/html` URI is decoded from base64 (assumed UTF-8) or percent-encoding as its parameters dictate. Anything
  * empty or undecodable yields `null`, which the template treats as "nothing to show".
  */
 function decodeHtmlFragment(value: string | null | undefined): string | null {

--- a/src/Indice.Features.Agents.App/src/app/features/chat/parts/chat-html.component.ts
+++ b/src/Indice.Features.Agents.App/src/app/features/chat/parts/chat-html.component.ts
@@ -53,7 +53,7 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation, computed, input 
   `,
   template: `
     @if (content(); as fragment) {
-      <div
+      <div title="{{ caption() || '' }}"
         class="dex-html text-[0.95rem]"
         [class.rounded-tl-sm]="first()"
         [class.dex-caret]="caret()"
@@ -65,6 +65,8 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation, computed, input 
 export class ChatHtmlComponent {
   /** The HTML fragment to render, or null when the part carried nothing renderable. */
   readonly html = input<string | null | undefined>(null);
+  /** The optional title or caption for the html fragment. */
+  readonly caption = input<string | null | undefined>(null);
   /** Whether this is the message's first part; only that one gets the bubble tail pointing at the avatar. */
   readonly first = input(false);
   /** Whether to show the blinking streaming caret. */

--- a/src/Indice.Features.Agents.App/src/app/features/chat/parts/part-contracts.spec.ts
+++ b/src/Indice.Features.Agents.App/src/app/features/chat/parts/part-contracts.spec.ts
@@ -22,6 +22,7 @@ describe('partKind', () => {
     // Prefix matching is the whole reason this is a function and not a template @switch.
     ['image/png', 'image'],
     ['image/svg+xml', 'image'],
+    ['text/html', 'html'],
     ['application/vnd.indice.not-invented-yet+json', 'unknown'],
     ['application/pdf', 'unknown'],
     [undefined, 'unknown'],

--- a/src/Indice.Features.Agents.App/src/app/features/chat/parts/part-contracts.ts
+++ b/src/Indice.Features.Agents.App/src/app/features/chat/parts/part-contracts.ts
@@ -21,7 +21,7 @@ export const CALLOUT_MEDIA_TYPE = 'application/vnd.indice.callout+json';
 export const CONFIRM_MEDIA_TYPE = 'application/vnd.indice.confirm+json';
 
 /** What `ChatMessagePartComponent` renders a part as. */
-export type PartKind = 'markdown' | 'image' | 'multiple-choice' | 'callout' | 'confirm' | 'unknown';
+export type PartKind = 'markdown' | 'html' | 'image' | 'multiple-choice' | 'callout' | 'confirm' | 'unknown';
 
 /**
  * Classifies a part by its `contentType`. This exists as a function rather than a plain `@switch` on the raw media type
@@ -34,6 +34,8 @@ export function partKind(contentType: string | undefined): PartKind {
     case 'text/markdown':
     case 'text':
       return 'markdown';
+    case 'text/html':
+      return 'html';
     case MULTIPLE_CHOICE_MEDIA_TYPE:
       return 'multiple-choice';
     case IMAGE_MEDIA_TYPE:

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/PurposeResponder.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/PurposeResponder.cs
@@ -75,9 +75,12 @@ internal class PurposeResponder : Executor<IntentOutput, GroundedAnswerOutput>
             await context.AddEventAsync(new AgentResponseUpdateEvent(Id, update), cancellationToken);
         }
         if(_options.DebugMode) {
-            await context.AddEventAsync(new AgentResponseUpdateEvent(Id,
-                                    new AgentResponseUpdate(ChatRole.Assistant, BuildContents())
-                                ), cancellationToken);
+            foreach (var demoPart in BuildContents()) {
+                await Task.Delay(200, cancellationToken);
+                await context.AddEventAsync(new AgentResponseUpdateEvent(Id,
+                    new AgentResponseUpdate(ChatRole.Assistant, [demoPart])
+                ), cancellationToken);
+            }
         }
         return new GroundedAnswerOutput(answer.ToString(), [], []);
 

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/PurposeResponder.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/PurposeResponder.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using System.Text;
 using Indice.Features.Agents.Core.Extensions;
 using Indice.Features.Agents.Core.Models;
@@ -88,6 +89,7 @@ internal class PurposeResponder : Executor<IntentOutput, GroundedAnswerOutput>
     /// </summary>
     public List<AIContent> BuildContents() {
         var contents = new List<AIContent> {
+            new TextContent("I can render text, images, callouts, confirmations, and multiple-choice prompts among others."),
             DataContentExtensions.JsonPart(new Callout {
                 Severity = Callout.Severities.Warning,
                 Title = "Outside my knowledge base",
@@ -99,6 +101,25 @@ internal class PurposeResponder : Executor<IntentOutput, GroundedAnswerOutput>
                 ImageReference.FromBytes(_logo, "image/png", caption: "Dex answers from your knowledge base."),
                 AgentsConstants.MediaTypes.Image),
             new DataContent(_logo, "image/png") { Name = "The same mark, carried as a bare image/png part." },
+            new DataContent($"data:,{Uri.EscapeDataString("""
+            <section class="dex-card">
+              <img src="https://i.pravatar.cc/160?img=32" alt="Maria Papadopoulou" />
+              <div>
+                <h3>Maria Papadopoulou</h3>
+                <p><span class="dex-badge">Customer Success</span> <span class="dex-muted">Support Department</span></p>
+                <ul>
+                  <li>📧 <a href="mailto:maria.papadopoulou@example.com">maria.papadopoulou@example.com</a></li>
+                  <li>📞 <a href="tel:+302101234567">+30 210 123 4567</a></li>
+                </ul>
+              </div>
+            </section>
+            """)}", MediaTypeNames.Text.Html) { Name = "I can render a beautiful HTML fragment" },
+            new DataContent($"data:,{Uri.EscapeDataString("""
+           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#04AA6D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M20 6L9 17l-5-5"/>
+            </svg>
+           """)}", MediaTypeNames.Image.Svg){ Name = "I can also render a Checkmark SVG" },
+
             DataContentExtensions.JsonPart(new Confirmation {
                 Prompt = "Want a hand finding something I do cover?",
                 ConfirmText = "Yes, what can you help with?",


### PR DESCRIPTION
Introduced ChatHtmlComponent to safely render text/html parts, including data URIs. Updated partKind and component switch logic to handle 'html' parts. Modified PurposeResponder.cs to emit example HTML content. Used Angular sanitizer for security and applied consistent styling with markdown.