### PR TITLE
[agents] Add content sanitization and refactor chat history

### DIFF
--- a/src/Indice.Features.Agents.Core/AgentsConstants.cs
+++ b/src/Indice.Features.Agents.Core/AgentsConstants.cs
@@ -41,9 +41,16 @@ public static class AgentsConstants
         public const string Callout = "application/vnd.indice.callout+json";
 
         /// <summary>A two-way confirmation; picking a button posts its label verbatim as the next user message. Payload: <see cref="Models.Confirmation"/>.</summary>
-        public const string Confirmation = "application/vnd.indice.confirm+json";    
+        public const string Confirmation = "application/vnd.indice.confirm+json";
+
+        /// <summary>A custom type to send html to agents that traditionally dont support parts of html.</summary>
+        public const string Html = "text/vnd.indice.html+json";
+
+        /// <summary>A custom type to send svg to other agents that traditionally dont support svg.</summary>
+        public const string Svg = "text/vnd.indice.svg+json";
+
     }
-  
+
     /// <summary>
     /// Semantic icon tokens advertised on <c>AgentInfo.Icon</c>. A token names what the flow *is*;
     /// the client maps it onto its own glyph set, so presentation stays a client concern. Clients

--- a/src/Indice.Features.Agents.Core/Extensions/DataContentExtensions.cs
+++ b/src/Indice.Features.Agents.Core/Extensions/DataContentExtensions.cs
@@ -9,7 +9,7 @@ namespace Indice.Features.Agents.Core.Extensions;
 public static class DataContentExtensions
 {
     /// <summary>Serializes a payload into the atomic <see cref="DataContent"/> part its media type stands for.</summary>
-    public static DataContent JsonPart<TPayload>(TPayload payload, string mediaType)
-        => new(JsonSerializer.SerializeToUtf8Bytes(payload), mediaType);
+    public static DataContent JsonPart<TPayload>(TPayload payload, string mediaType, string? name=null)
+        => new(JsonSerializer.SerializeToUtf8Bytes(payload), mediaType) { Name = name };
 
 }

--- a/src/Indice.Features.Agents.Core/Services/ContentSanitizer.cs
+++ b/src/Indice.Features.Agents.Core/Services/ContentSanitizer.cs
@@ -4,7 +4,8 @@ using Microsoft.Extensions.AI;
 namespace Indice.Features.Agents.Core.Services;
 
 /// <summary>
-/// 
+/// Sanitizes <see cref="AIContent"/> parts by downgrading or re-typing unsafe media types (e.g. SVG/HTML)
+/// so downstream renderers don't treat them as executable content.
 /// </summary>
 public static class ContentSanitizer
 {

--- a/src/Indice.Features.Agents.Core/Services/ContentSanitizer.cs
+++ b/src/Indice.Features.Agents.Core/Services/ContentSanitizer.cs
@@ -1,0 +1,40 @@
+﻿using System.Net.Mime;
+using Microsoft.Extensions.AI;
+
+namespace Indice.Features.Agents.Core.Services;
+
+/// <summary>
+/// 
+/// </summary>
+public static class ContentSanitizer
+{
+    /// <summary>
+    /// Attempts to sanitize the <see cref="AIContent"/> parts in the list, modifying them in place. For example, it can remove potentially harmful content or format the text appropriately based on its media type.
+    /// </summary>
+    /// <param name="parts"></param>
+    /// <returns></returns>
+    public static IList<AIContent> ToSanitized(this IList<AIContent> parts) {
+        IList<AIContent> sanitizedParts = new List<AIContent>();
+        foreach (var part in parts) {
+            if (part is DataContent dataContent) {
+                switch(dataContent.MediaType) {
+                    case MediaTypeNames.Image.Svg:
+                        sanitizedParts.Add(new DataContent(dataContent.Data,"text/vnd.indice+svg") { Name = dataContent.Name});
+                        break;
+                    case MediaTypeNames.Text.Html:
+                        var textContent = new DataContent(dataContent.Data,"text/vnd.indice+html") { Name = dataContent.Name };
+                        sanitizedParts.Add(textContent);
+                        break;
+                    default:
+                        sanitizedParts.Add(dataContent);
+                        break;
+                }
+            }
+            else {
+                sanitizedParts.Add(part);
+            }
+        }
+        return sanitizedParts;
+    }
+
+}

--- a/src/Indice.Features.Agents.Core/Services/ContentSanitizer.cs
+++ b/src/Indice.Features.Agents.Core/Services/ContentSanitizer.cs
@@ -13,16 +13,16 @@ public static class ContentSanitizer
     /// </summary>
     /// <param name="parts"></param>
     /// <returns></returns>
-    public static IList<AIContent> ToSanitized(this IList<AIContent> parts) {
+    public static IList<AIContent> Sanitize(this IList<AIContent> parts) {
         IList<AIContent> sanitizedParts = new List<AIContent>();
         foreach (var part in parts) {
             if (part is DataContent dataContent) {
                 switch(dataContent.MediaType) {
                     case MediaTypeNames.Image.Svg:
-                        sanitizedParts.Add(new DataContent(dataContent.Data,"text/vnd.indice+svg") { Name = dataContent.Name});
+                        sanitizedParts.Add(new DataContent(dataContent.Data,AgentsConstants.MediaTypes.Svg) { Name = dataContent.Name});
                         break;
                     case MediaTypeNames.Text.Html:
-                        var textContent = new DataContent(dataContent.Data,"text/vnd.indice+html") { Name = dataContent.Name };
+                        var textContent = new DataContent(dataContent.Data,AgentsConstants.MediaTypes.Html) { Name = dataContent.Name };
                         sanitizedParts.Add(textContent);
                         break;
                     default:

--- a/src/Indice.Features.Agents.Core/Services/ConversationStoreChatHistoryProvider.cs
+++ b/src/Indice.Features.Agents.Core/Services/ConversationStoreChatHistoryProvider.cs
@@ -1,6 +1,8 @@
+using System.Net.Mime;
+using System.Text;
 using Indice.Features.Agents.Core.Services;
 using Microsoft.Agents.AI;
-
+using Microsoft.Extensions.AI;
 namespace Indice.Features.Agents.Core.Workflows;
 
 /// <summary>
@@ -45,6 +47,10 @@ public sealed class ConversationStoreChatHistoryProvider : ChatHistoryProvider
             return [];
         }
         var history = await _store.GetHistoryAsync(conversationId, cancellationToken);
+        //here I want to filter them
+        foreach (var message in history) {
+            message.Contents = ContentSanitizer.ToSanitized(message.Contents);
+        }
         return history;
     }
 
@@ -56,4 +62,5 @@ public sealed class ConversationStoreChatHistoryProvider : ChatHistoryProvider
     {
         public Guid ConversationId { get; set; }
     }
+
 }

--- a/src/Indice.Features.Agents.Core/Services/ConversationStoreChatHistoryProvider.cs
+++ b/src/Indice.Features.Agents.Core/Services/ConversationStoreChatHistoryProvider.cs
@@ -47,9 +47,8 @@ public sealed class ConversationStoreChatHistoryProvider : ChatHistoryProvider
             return [];
         }
         var history = await _store.GetHistoryAsync(conversationId, cancellationToken);
-        //here I want to filter them
         foreach (var message in history) {
-            message.Contents = ContentSanitizer.ToSanitized(message.Contents);
+            message.Contents = ContentSanitizer.Sanitize(message.Contents);
         }
         return history;
     }


### PR DESCRIPTION
- Introduced ContentSanitizer with ToSanitized for IList<AIContent>
- Updated ConversationStoreChatHistoryProvider to sanitize messages
- Enhanced DataContentExtensions.JsonPart with optional name parameter
