### PR TITLE
🛠️[core] Refactor push notification service factory usage

### DIFF
--- a/src/Indice.Common/Services/IPushNotificationService.cs
+++ b/src/Indice.Common/Services/IPushNotificationService.cs
@@ -135,9 +135,9 @@ public static class PushNotificationServiceExtensions
 public interface IPushNotificationServiceFactory
 {
     /// <summary>Creates an instance of an <see cref="IPushNotificationService"/></summary>
-    /// <param name="name"></param>
-    /// <returns></returns>
-    IPushNotificationService Create(string name);
+    /// <param name="name">The name/key that the push notification service has been configured with, otherwize null to get the default version.</param>
+    /// <returns>A push notification service instance</returns>
+    IPushNotificationService Create(string? name);
 }
 
 /// <inheritdoc/>
@@ -147,5 +147,16 @@ public class DefaultPushNotificationServiceFactory(IServiceProvider serviceProvi
     private IServiceProvider _serviceProvider { get; } = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
 
     /// <inheritdoc />
-    public IPushNotificationService Create(string name) => _serviceProvider.GetKeyedService<IPushNotificationService>(name) ?? new PushNotificationServiceNoop();
+    public IPushNotificationService Create(string? name) => (string.IsNullOrWhiteSpace(name) ? 
+                                                            _serviceProvider.GetService<IPushNotificationService>() : 
+                                                            _serviceProvider.GetKeyedService<IPushNotificationService>(name))
+        ?? new PushNotificationServiceNoop();
+}
+
+
+/// <summary>Extensions for <see cref="IPushNotificationServiceFactory"/>.</summary>
+public static class PushNotificationServiceFactoryExtensions 
+{
+    /// <summary>Creates the default instance of an <see cref="IPushNotificationService"/>.</summary>
+    public static IPushNotificationService Create(this IPushNotificationServiceFactory factory) => factory.Create(name: null);
 }

--- a/src/Indice.Common/Services/IPushNotificationService.cs
+++ b/src/Indice.Common/Services/IPushNotificationService.cs
@@ -135,7 +135,7 @@ public static class PushNotificationServiceExtensions
 public interface IPushNotificationServiceFactory
 {
     /// <summary>Creates an instance of an <see cref="IPushNotificationService"/></summary>
-    /// <param name="name">The name/key that the push notification service has been configured with, otherwize null to get the default version.</param>
+    /// <param name="name">The name/key that the push notification service has been configured with, otherwise null to get the default version.</param>
     /// <returns>A push notification service instance</returns>
     IPushNotificationService Create(string? name);
 }

--- a/src/Indice.Features.Identity.Core/Grants/GuestGrantValidator.cs
+++ b/src/Indice.Features.Identity.Core/Grants/GuestGrantValidator.cs
@@ -24,7 +24,7 @@ using IdentityServer4.Validation;
 namespace Indice.Features.Identity.Core.Grants;
 
 /// <summary>A custom <see cref="IExtensionGrantValidator"/> that issues short-lived tokens for anonymous (guest) users.</summary>
-/// <param name="pushNotificationService">The push notification service used to register the guest device for push notifications.</param>
+/// <param name="pushNotificationServiceFactory">The push notification service used to register the guest device for push notifications.</param>
 /// <param name="logger">The logger instance.</param>
 /// <remarks>
 /// The effective subject is echoed back through the token response custom field <c>sub</c>, so callers do not need to parse the access token.
@@ -32,7 +32,7 @@ namespace Indice.Features.Identity.Core.Grants;
 /// Subclass and override <see cref="GetClaimsAsync"/> to validate additional request data and enrich the issued claims,
 /// then register the subclass through <c>AddGuestGrantValidator&lt;TValidator&gt;()</c>.
 /// </remarks>
-public class GuestGrantValidator(IPushNotificationService pushNotificationService, ILogger<GuestGrantValidator> logger) : IExtensionGrantValidator
+public class GuestGrantValidator(IPushNotificationServiceFactory pushNotificationServiceFactory, ILogger<GuestGrantValidator> logger) : IExtensionGrantValidator
 {
     /// <summary>The identity provider value used to discriminate guest identities.</summary>
     public const string IdentityProviderName = "guest";
@@ -41,7 +41,7 @@ public class GuestGrantValidator(IPushNotificationService pushNotificationServic
     public string GrantType => CustomGrantTypes.Guest;
 
     /// <summary>The push notification service used to register the guest device for push notifications.</summary>
-    public IPushNotificationService PushNotificationService { get; } = pushNotificationService;
+    public IPushNotificationServiceFactory PushNotificationServiceFactory { get; } = pushNotificationServiceFactory;
 
     /// <summary>The logger instance.</summary>
     public ILogger<GuestGrantValidator> Logger { get; } = logger;
@@ -74,6 +74,7 @@ public class GuestGrantValidator(IPushNotificationService pushNotificationServic
     /// In case the registration fails, the exception is swallowed and logged.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when the device fields are not in the correct format.</exception>
     protected async Task TryRegisterToPushNotificationsAsync(ExtensionGrantValidationContext context, string subject) {
+        var pushNotificationService = PushNotificationServiceFactory.Create();
         var raw = context.Request.Raw;
         var deviceId = raw.Get(GuestGrantRequestParameterNames.DeviceId)?.Trim();
         var devicePlatform = raw.Get(GuestGrantRequestParameterNames.DevicePlatform)?.Trim();
@@ -86,7 +87,7 @@ public class GuestGrantValidator(IPushNotificationService pushNotificationServic
             Guard.TooLong(devicePlatform, TextSizePresets.S32, GuestGrantRequestParameterNames.DevicePlatform);
             var platform = Guard.DevicePlatform(devicePlatform, GuestGrantRequestParameterNames.DevicePlatform);
             try {
-                await PushNotificationService.Register(deviceId, pnsHandle, platform, subject);
+                await pushNotificationService.Register(deviceId, pnsHandle, platform, subject);
             } 
             catch (Exception ex) {
                 Logger.LogError(ex, "Failed to register push notification user handle.");

--- a/src/Indice.Features.Identity.Core/Grants/GuestGrantValidator.cs
+++ b/src/Indice.Features.Identity.Core/Grants/GuestGrantValidator.cs
@@ -24,7 +24,7 @@ using IdentityServer4.Validation;
 namespace Indice.Features.Identity.Core.Grants;
 
 /// <summary>A custom <see cref="IExtensionGrantValidator"/> that issues short-lived tokens for anonymous (guest) users.</summary>
-/// <param name="pushNotificationServiceFactory">The push notification service used to register the guest device for push notifications.</param>
+/// <param name="pushNotificationServiceFactory">The push notification service factory to create a service instance used to register the guest device for push notifications.</param>
 /// <param name="logger">The logger instance.</param>
 /// <remarks>
 /// The effective subject is echoed back through the token response custom field <c>sub</c>, so callers do not need to parse the access token.

--- a/src/Indice.Features.Messages.Core/Manager/NotificationsManager.cs
+++ b/src/Indice.Features.Messages.Core/Manager/NotificationsManager.cs
@@ -264,7 +264,7 @@ public class NotificationsManager(
     /// <param name="name">The name used to create a new campaign type.</param>
     public async Task<CreateMessageTypeResult> CreateMessageType(string name) {
         var campaignType = new CreateMessageTypeRequest { Name = name };
-        var validationResult = MessageTypeValidator.Validate(campaignType);
+        var validationResult = await MessageTypeValidator.ValidateAsync(campaignType);
         if (!validationResult.IsValid) {
             var errorMessages = validationResult.Errors.Select(x => x.ErrorMessage).ToArray();
             return CreateMessageTypeResult.Fail(errorMessages);

--- a/test/Indice.Features.Identity.Tests/GuestGrantIntegrationTests.cs
+++ b/test/Indice.Features.Identity.Tests/GuestGrantIntegrationTests.cs
@@ -123,8 +123,8 @@ public class GuestGrantIntegrationTests
         Assert.Equal("+30 6900000000", token.Claims.First(claim => claim.Type == "phone_number").Value);
     }
 
-    private class OpinionatedGuestGrantValidator(IPushNotificationService pushNotificationService, ILogger<GuestGrantValidator> logger) 
-        : GuestGrantValidator(pushNotificationService, logger)
+    private class OpinionatedGuestGrantValidator(IPushNotificationServiceFactory pushNotificationServiceFactory, ILogger<GuestGrantValidator> logger) 
+        : GuestGrantValidator(pushNotificationServiceFactory, logger)
     {
 
         protected override Task<IEnumerable<Claim>> GetClaimsAsync(ExtensionGrantValidationContext context, string subject) =>


### PR DESCRIPTION
- Updated IPushNotificationServiceFactory and DefaultPushNotificationServiceFactory to allow nullable service names in Create method, resolving default or keyed services accordingly.
- Added PushNotificationServiceFactoryExtensions with an extension method for creating the default service.
- Changed api_url in environment.ts to production endpoint.
- Refactored GuestGrantValidator to depend on the factory instead of a concrete service, resolving the service at runtime.
- Modified TryRegisterToPushNotificationsAsync to obtain the service instance via the factory.
- Fixed a sync Validator call chain in `NotificationsManager` that used FluentValidator under the hood from an asynchronous context and failed with exception