### PR TITLE
🤖[agents] Add dynamic agent registration and routing system

### DIFF
--- a/src/Indice.Features.Agents.Core/AgentDefinition.cs
+++ b/src/Indice.Features.Agents.Core/AgentDefinition.cs
@@ -1,0 +1,47 @@
+using Microsoft.Agents.AI;
+
+namespace Indice.Features.Agents.Core;
+
+/// <summary>
+/// Describes one routable agent in the Agents catalogue: the metadata advertised on the discovery endpoint and offered to the
+/// intent router as a handoff target, plus the factory that materialises the underlying <see cref="AIAgent"/> for a chat turn.
+/// Register instances with <c>AddAgent</c> (a ready <see cref="AIAgent"/>) or <c>AddAgentWorkflow</c> (a MAF <c>Workflow</c> wrapped as an agent).
+/// </summary>
+public class AgentDefinition
+{
+    /// <summary>Unique, URL-safe agent name. It is the value clients send as <c>agentName</c> and the id of the handoff tool the router calls.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>What the agent does, in one or two sentences. Shown to users on discovery and to the intent router when it picks a target.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>Semantic icon token from <see cref="AgentsConstants.AgentIcons"/>.</summary>
+    public string? Icon { get; init; }
+
+    /// <summary>Free-form tags advertised on discovery.</summary>
+    public List<string> Tags { get; init; } = [];
+
+    /// <summary>Capabilities advertised on discovery.</summary>
+    public List<AgentCapabilityDefinition> Capabilities { get; init; } = [];
+
+    /// <summary>
+    /// True for the master intent router itself. Router definitions are advertised on discovery but are never offered as handoff targets.
+    /// </summary>
+    public bool IsRouter { get; init; }
+
+    /// <summary>
+    /// Creates the <see cref="AIAgent"/> that handles a chat turn. Invoked once per request with the request-scoped service provider.
+    /// Set by <c>AddAgentWorkflow</c>; required when registering through <c>AddAgent</c>.
+    /// </summary>
+    public Func<IServiceProvider, AIAgent>? CreateAgent { get; set; }
+}
+
+/// <summary>A named capability of an <see cref="AgentDefinition"/>, advertised on the discovery endpoint.</summary>
+public class AgentCapabilityDefinition
+{
+    /// <summary>Short capability name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>One-sentence description of the capability.</summary>
+    public required string Description { get; init; }
+}

--- a/src/Indice.Features.Agents.Core/AgentsChatClient.cs
+++ b/src/Indice.Features.Agents.Core/AgentsChatClient.cs
@@ -1,35 +1,60 @@
 using System.Runtime.CompilerServices;
-using Indice.Features.Agents.Core.Workflows.State;
+using Indice.Features.Agents.Core.Workflows;
 using Microsoft.Agents.AI;
-using Microsoft.Agents.AI.Workflows;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Indice.Features.Agents.Core;
 
-/// <summary>Entry point for executing the Dex RAG pipeline against a single user question.</summary>
+/// <summary>Entry point for executing a chat turn against one of the registered agents.</summary>
 public interface IDexChatClient : IChatClient
 {
 }
 
-/// <inheritdoc/>
 /// <summary>
-/// Creates a new <see cref="AgentsChatClient"/> instance.
+/// <see cref="IChatClient"/> facade over the Agents catalogue. Resolves the requested agent (<see cref="ChatOptions.Instructions"/>
+/// carries the <c>agentName</c> from the HTTP layer), runs it through the Agent Framework agent surface and projects its streaming
+/// updates onto <see cref="ChatResponseUpdate"/>s. Workflows reach here already wrapped as agents (see
+/// <c>AddAgentWorkflow</c>), so one code path serves the intent router, the knowledge pipeline and any custom agent.
 /// </summary>
-/// <param name="serviceProvider">The service provider for resolving dependencies.</param>
-public class AgentsChatClient(IServiceProvider serviceProvider) : IDexChatClient
+public class AgentsChatClient : IDexChatClient
 {
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IReadOnlyDictionary<string, AgentDefinition> _agents;
+    private readonly AgentsOptions.RoutingOptions _routing;
+    private readonly ILogger<AgentsChatClient> _logger;
 
-    /// <summary>Human-friendly progress labels keyed by executor id, surfaced as SSE <c>step</c> events.</summary>
-    private static readonly IReadOnlyDictionary<string, string> StepLabels = new Dictionary<string, string>(StringComparer.Ordinal) {
-        ["IntentClassifier"] = "Classifying intent",
-        ["QueryRewriter"] = "Rewriting query",
-        ["Retriever"] = "Retrieving relevant context",
-        ["Reranker"] = "Ranking results",
-        ["AnswerComposer"] = "Composing answer",
-        ["PurposeResponder"] = "Answering",
-        ["OutOfScopeResponder"] = "Preparing response",
-    };
+    /// <summary>Creates a new <see cref="AgentsChatClient"/>.</summary>
+    /// <param name="serviceProvider">The request-scoped service provider handed to agent factories.</param>
+    /// <param name="agents">The registered agents.</param>
+    /// <param name="options">Agents options; <see cref="AgentsOptions.Routing"/> decides the fallback agent.</param>
+    /// <param name="logger">The logger.</param>
+    public AgentsChatClient(IServiceProvider serviceProvider, IEnumerable<AgentDefinition> agents, IOptions<AgentsOptions> options, ILogger<AgentsChatClient> logger) {
+        _serviceProvider = serviceProvider;
+        _agents = agents.ToDictionary(definition => definition.Name, StringComparer.OrdinalIgnoreCase);
+        _routing = options.Value.Routing;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Picks the agent to run: the requested name when it is registered, else the configured default agent when registered,
+    /// else <see cref="AgentsConstants.AgentNames.Knowledge"/>. Matching is case-insensitive; the registered spelling is returned.
+    /// </summary>
+    public static string ResolveAgentName(string? requested, IEnumerable<string> registered, string? defaultAgent) {
+        ArgumentNullException.ThrowIfNull(registered);
+        var names = registered as ICollection<string> ?? registered.ToList();
+        var wanted = requested?.Trim();
+        if (!string.IsNullOrEmpty(wanted) && names.FirstOrDefault(name => name.Equals(wanted, StringComparison.OrdinalIgnoreCase)) is { } match) {
+            return match;
+        }
+        var fallback = defaultAgent?.Trim();
+        if (!string.IsNullOrEmpty(fallback) && names.FirstOrDefault(name => name.Equals(fallback, StringComparison.OrdinalIgnoreCase)) is { } defaultMatch) {
+            return defaultMatch;
+        }
+        return AgentsConstants.AgentNames.Knowledge;
+    }
 
     /// <inheritdoc/>
     public async Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default) {
@@ -48,52 +73,91 @@ public class AgentsChatClient(IServiceProvider serviceProvider) : IDexChatClient
             throw new ArgumentException("DexChatClient only supports a single user message per request. No batching allowed.", nameof(messages));
         }
         var message = messages.First();
-        var state = new ConversationState(message, options?.ConversationId ?? Guid.NewGuid().ToString());
-        // Use options.Instructions as the agent/workflow selector passed from the HTTP layer (ChatRequest.AgentName).
-        // Supported selectors: "auto", "knowledge". Unknown or missing values fall back to "knowledge".
+        var conversationId = Guid.TryParse(options?.ConversationId, out var parsed) ? parsed : Guid.NewGuid();
+        var conversationIdText = conversationId.ToString();
+        // Agents receive the message through the framework without our session or workflow state; the id rides on the message.
+        message.SetConversationId(conversationId);
+        // Dex models a turn as one assistant message (the store persists the first message, the stream projects into
+        // /messages/0). Framework-hosted agents stamp their own message ids per hop, which would split the aggregated
+        // response into several messages, so every update of the turn is re-stamped with one message/response id.
+        var turnMessageId = Guid.NewGuid().ToString("N");
+        var turnResponseId = Guid.NewGuid().ToString("N");
 
-        var agenticWorkflowName = options?.Instructions?.Trim().ToLowerInvariant() switch {
-            AgentsConstants.AgentNames.Auto => AgentsConstants.AgentNames.Auto,
-            AgentsConstants.AgentNames.Knowledge => AgentsConstants.AgentNames.Knowledge,
-            _ => AgentsConstants.AgentNames.Knowledge
-        };
-        var workflow = serviceProvider.GetKeyedService<Workflow>(agenticWorkflowName) ?? serviceProvider.GetRequiredKeyedService<Workflow>(AgentsConstants.AgentNames.Knowledge);
+        var agentName = ResolveAgentName(options?.Instructions, _agents.Keys, _routing.DefaultAgent);
+        if (!_agents.TryGetValue(agentName, out var definition)) {
+            throw new InvalidOperationException($"Agent '{agentName}' is not registered. Register it with AddAgent or AddAgentWorkflow, or point Dex:Routing:DefaultAgent to a registered agent.");
+        }
+        _logger.LogInformation("Conversation {ConversationId}: agent '{Agent}' selected (requested '{Requested}').", conversationIdText, definition.Name, options?.Instructions);
 
-        await using var run = await InProcessExecution.RunStreamingAsync(workflow, state, sessionId: state.ConversationId, cancellationToken: cancellationToken);
+        var agent = definition.CreateAgent!(_serviceProvider);
+        var session = await agent.CreateSessionAsync(cancellationToken);
+        ConversationStoreChatHistoryProvider.SetSessionId(session, conversationId);
+        if (definition.IsRouter) {
+            yield return Stamp(new ChatResponseUpdate(ChatRole.Assistant, [new StepProgressContent("Selecting agent")]));
+        }
 
+        // Run failures surface either as ErrorContent updates (workflow-hosted agents) or as exceptions; both end the turn
+        // with an ErrorContent the chats service reports. Walk to the innermost exception for the real cause.
         string? failure = null;
-        await foreach (var evt in run.WatchStreamAsync().WithCancellation(cancellationToken)) {
-            switch (evt) {
-                case AgentResponseUpdateEvent updateEvent:
-                    var update = updateEvent.Update.AsChatResponseUpdate();
-                    update.ConversationId = state.ConversationId;
-                    yield return update;
+        await using var enumerator = agent.RunStreamingAsync(new List<ChatMessage> { message }, session, cancellationToken: cancellationToken).GetAsyncEnumerator(cancellationToken);
+        while (true) {
+            AgentResponseUpdate update;
+            try {
+                if (!await enumerator.MoveNextAsync()) {
                     break;
-                // One progress event per step start; unmapped executor ids are skipped. Emitted as ephemeral content, stripped from the composed response.
-                case ExecutorInvokedEvent invoked when StepLabels.TryGetValue(invoked.ExecutorId, out var label):
-                    yield return new ChatResponseUpdate(ChatRole.Assistant, [new StepProgressContent(label)]) { ConversationId = state.ConversationId };
-                    break;
-                // A throwing step halts the run; keep the first (richer) message. The runtime wraps executor
-                // exceptions ("Error invoking handler for ..."), so walk to the innermost exception for the real cause.
-                case WorkflowErrorEvent error:
-                    var exception = error.Data as Exception;
-                    while (exception?.InnerException is not null) {
-                        exception = exception.InnerException;
-                    }
-                    failure ??= exception?.Message ?? "Workflow failed without exception details.";
-                    yield return new ChatResponseUpdate(ChatRole.Assistant, [new ErrorContent(failure)]) { ConversationId = state.ConversationId };
-                    break;
-                default:
-                    //Console.WriteLine(evt);
-                    break;
+                }
+                update = enumerator.Current;
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception exception) {
+                while (exception.InnerException is not null) {
+                    exception = exception.InnerException;
+                }
+                failure = exception.Message;
+                break;
             }
+            if (IsRouterUpdate(update)) {
+                // The router's output is its handoff tool call; nothing it says is meant for the user. Keep its token usage only.
+                var usage = update.Contents.OfType<UsageContent>().ToList<AIContent>();
+                if (usage.Count == 0) {
+                    continue;
+                }
+                yield return Stamp(new ChatResponseUpdate(ChatRole.Assistant, usage));
+                continue;
+            }
+            yield return Stamp(Project(update));
+        }
+        if (failure is not null) {
+            yield return Stamp(new ChatResponseUpdate(ChatRole.Assistant, [new ErrorContent(failure)]));
         }
         // Cancellation just stops the stream rather than raising a failure event — surface it as cancellation.
         cancellationToken.ThrowIfCancellationRequested();
+
+        ChatResponseUpdate Stamp(ChatResponseUpdate update) {
+            update.ConversationId = conversationIdText;
+            update.MessageId = turnMessageId;
+            update.ResponseId = turnResponseId;
+            return update;
+        }
     }
 
+    private static bool IsRouterUpdate(AgentResponseUpdate update)
+        => string.Equals(update.AgentId, AgentsConstants.IntentRouter.AgentId, StringComparison.Ordinal)
+        || string.Equals(update.AuthorName, AgentsConstants.IntentRouter.AgentName, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Copies the framework's update into a fresh <see cref="ChatResponseUpdate"/>. The framework keeps merging the update
+    /// instances it handed out (handoff context sync, response aggregation), so ids are never re-stamped on its own objects.
+    /// </summary>
+    private static ChatResponseUpdate Project(AgentResponseUpdate update) => new(update.Role, update.Contents.ToList()) {
+        AuthorName = update.AuthorName,
+        CreatedAt = update.CreatedAt,
+        FinishReason = update.FinishReason,
+        AdditionalProperties = update.AdditionalProperties,
+    };
+
     /// <inheritdoc/>
-    public object? GetService(Type serviceType, object? serviceKey = null) => serviceKey is null ? serviceProvider.GetService(serviceType) : serviceProvider.GetKeyedService(serviceType, serviceKey);
+    public object? GetService(Type serviceType, object? serviceKey = null) => serviceKey is null ? _serviceProvider.GetService(serviceType) : _serviceProvider.GetKeyedService(serviceType, serviceKey);
 
     /// <inheritdoc/>
     public void Dispose() {

--- a/src/Indice.Features.Agents.Core/AgentsConstants.cs
+++ b/src/Indice.Features.Agents.Core/AgentsConstants.cs
@@ -15,6 +15,23 @@ public static class AgentsConstants
         public const string Auto = "auto";
     }
 
+    /// <summary>Identity of the master intent router agent inside the <see cref="AgentNames.Auto"/> handoff workflow.</summary>
+    public static class IntentRouter
+    {
+        /// <summary>The router's <c>AIAgent.Id</c>. Stamped on its response updates, which the chat client suppresses.</summary>
+        public const string AgentId = "router";
+
+        /// <summary>The router's <c>AIAgent.Name</c>.</summary>
+        public const string AgentName = "IntentRouter";
+    }
+
+    /// <summary>Keys of <c>ChatMessage.AdditionalProperties</c> entries the pipeline relies on.</summary>
+    public static class MessageProperties
+    {
+        /// <summary>The Dex conversation (chat session) a message belongs to, as a <see cref="Guid"/> string. See <c>ConversationMessageExtensions</c>.</summary>
+        public const string ConversationId = "conversationId";
+    }
+
     /// <summary>Media types of the alternative (non-prose) content parts an assistant turn can carry.</summary>
     /// <remarks>
     /// Each one is a rendering contract between the pipeline and the chat UI: a part with this media type carries a
@@ -117,6 +134,23 @@ public static class AgentsConstants
         /// <summary>Prompt template for reranking candidate passages.</summary>
         public const string Reranker = """
             You are a reranker for a retrieval system. The user message may contain a HISTORY: block with the recent conversation (oldest-first) before the question. You are given a list of candidate passages, each with an ID and text. Rank the candidates by relevance to the question, considering the HISTORY for context. Return a JSON object { "rankedCandidates": [{ "id": "...", "text": "..." }, ...] } in order of descending relevance. If none are relevant, return an empty array.
+            """;
+
+        /// <summary>Prompt template for the master intent router. Rendered with <c>agents</c> (name + description of every handoff target) and <c>defaultTarget</c>.</summary>
+        public const string IntentRouter = """
+            You are the intent router of an enterprise assistant. You never answer the user yourself. Your only job is to read the
+            latest user message, in the context of the conversation history, and hand the conversation off to exactly one of the
+            specialised agents below by calling its handoff tool.
+
+            Available agents:
+            {{#each agents}}
+            - {{name}}: {{description}}
+            {{/each}}
+
+            Rules:
+            - Always call exactly one handoff tool. Never reply with text, never ask clarifying questions, never answer the question yourself.
+            - A follow-up such as "tell me more" or "and the second one?" belongs to the agent that handled the previous turn.
+            - When unsure, hand off to "{{defaultTarget}}".
             """;
     }
 }

--- a/src/Indice.Features.Agents.Core/AgentsFeatureExtensions.cs
+++ b/src/Indice.Features.Agents.Core/AgentsFeatureExtensions.cs
@@ -6,6 +6,7 @@ using Indice.Features.Agents.Core.Services;
 using Indice.Features.Agents.Core.Workflows;
 using Indice.Features.Agents.Core.Workflows.Prompts;
 using Indice.Features.Agents.Core.Workflows.Reranking;
+using Indice.Features.Agents.Core.Workflows.Routing;
 using Indice.Features.Agents.Core.Workflows.Steps;
 using Microsoft.Agents.AI.Workflows;
 using Microsoft.EntityFrameworkCore;
@@ -80,14 +81,18 @@ public static class AgentsFeatureExtensions
         );
         services.TryAddSingleton<ISourceLinkGenerator, NoOpSourceLinkGenerator>();
         services.AddAgentsDefaultPipeline();
+        services.AddAgentsIntentRouter();
         return services;
     }
 
     /// <summary>
-    /// Registers the five default steps, the default <see cref="ILlmReranker"/>, and a scoped
-    /// <see cref="Workflow"/> wiring them in order. Call after <c>AddDex(...)</c>.
+    /// Registers the knowledge pipeline: its steps, the default <see cref="ILlmReranker"/>, and the
+    /// <see cref="AgentsConstants.AgentNames.Knowledge"/> agent (a scoped <see cref="Workflow"/> wiring the steps in order, exposed
+    /// as an agent through <see cref="AgentsRegistrationExtensions.AddAgentWorkflow"/>). Called by <see cref="AddAgentsCore"/>.
     /// </summary>
     public static IServiceCollection AddAgentsDefaultPipeline(this IServiceCollection services) {
+        services.TryAddTransient<KnowledgeEntry>();
+        services.TryAddTransient<KnowledgeSeed>();
         services.TryAddTransient<IntentClassifier>();
         services.TryAddTransient<QueryRewriter>();
         services.TryAddTransient<Retriever>();
@@ -97,9 +102,18 @@ public static class AgentsFeatureExtensions
         services.TryAddTransient<PurposeResponder>();
         services.TryAddTransient<ILlmReranker, LlmListwiseReranker>();
 
-        // Register the workflow, which will resolve the steps and link them together. Step failures are not
-        // handled here — a throwing executor halts the run and DexRunner reads the ExecutorFailedEvent.
-        services.AddKeyedScoped(AgentsConstants.AgentNames.Knowledge, (sp, key) => {
+        // Register the workflow, which resolves the steps and links them together. Step failures are not handled
+        // here — a throwing executor halts the run and surfaces as ErrorContent on the hosting agent's response.
+        var knowledge = new AgentDefinition {
+            Name = AgentsConstants.AgentNames.Knowledge,
+            Description = "This is an agent that can answer questions based on a knowledge base.",
+            Icon = AgentsConstants.AgentIcons.Book,
+            Tags = ["Knowledge", "FAQ"],
+            Capabilities = [new AgentCapabilityDefinition { Name = "Knowledge retrieval", Description = "Answers questions based on a knowledge base." }],
+        };
+        services.AddAgentWorkflow(knowledge, sp => {
+            var entry = sp.GetRequiredService<KnowledgeEntry>();
+            var seed = sp.GetRequiredService<KnowledgeSeed>();
             var intent = sp.GetRequiredService<IntentClassifier>();
             var rewrite = sp.GetRequiredService<QueryRewriter>();
             var retrieve = sp.GetRequiredService<Retriever>();
@@ -108,7 +122,9 @@ public static class AgentsFeatureExtensions
             var outOfScopeReply = sp.GetRequiredService<OutOfScopeResponder>();
             var purposeResponder = sp.GetRequiredService<PurposeResponder>();
 
-            var builder = new WorkflowBuilder(intent);
+            var builder = new WorkflowBuilder(entry);
+            builder.AddEdge(entry, seed);
+            builder.AddEdge(seed, intent);
             builder.AddSwitch(intent, sw => sw
                 .AddCase<IntentOutput>(env => env!.Intent.Category == "purpose_of_agent", purposeResponder)
                 .AddCase<IntentOutput>(env => env!.Intent.IsInScope, rewrite)
@@ -119,6 +135,26 @@ public static class AgentsFeatureExtensions
             builder.WithOutputFrom(compose, outOfScopeReply, purposeResponder);
             return builder.Build();
         });
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the <see cref="AgentsConstants.AgentNames.Auto"/> agent: the master intent router, a handoff orchestration whose
+    /// targets are every other registered agent (resolved per request, so registration order does not matter).
+    /// </summary>
+    public static IServiceCollection AddAgentsIntentRouter(this IServiceCollection services) {
+        var auto = new AgentDefinition {
+            Name = AgentsConstants.AgentNames.Auto,
+            Description = "This is an agent that discovers user intent and passes it to the appropriate sub agent.",
+            Icon = AgentsConstants.AgentIcons.Sparkles,
+            Tags = ["Intent"],
+            Capabilities = [new AgentCapabilityDefinition { Name = "Master intent classification", Description = "Discovers user intent and routes it to the appropriate sub-agent." }],
+            IsRouter = true,
+        };
+        auto.CreateAgent = sp => IntentRouterFactory
+            .CreateHandoffWorkflow(sp)
+            .AsAIAgent(id: auto.Name, name: auto.Name, description: auto.Description, includeExceptionDetails: true);
+        services.AddAgent(auto);
         return services;
     }
 }

--- a/src/Indice.Features.Agents.Core/AgentsOptions.cs
+++ b/src/Indice.Features.Agents.Core/AgentsOptions.cs
@@ -28,6 +28,9 @@ public class AgentsOptions
     /// <summary>Allowed categorical/language values constrained by the host application.</summary>
     public TaxonomyOptions Taxonomy { get; set; } = new();
 
+    /// <summary>Agent selection behaviour (default agent, intent routing).</summary>
+    public RoutingOptions Routing { get; set; } = new();
+
     /// <summary>
     /// When true we enable additional triggers and debug handles for development and testing. 
     /// This is not a security boundary; do not rely on it to protect sensitive data. 
@@ -168,6 +171,17 @@ public class AgentsOptions
 
         /// <summary>Allowed ISO-639-1 (or BCP-47) language codes.</summary>
         public IReadOnlyList<string> Languages { get; set; } = ["en", "el", "de", "fr", "es"];
+    }
+
+    /// <summary>Agent selection behaviour.</summary>
+    public class RoutingOptions
+    {
+        /// <summary>
+        /// Name of the registered agent used when a chat request omits <c>agentName</c> or names an agent that is not registered.
+        /// Defaults to <see cref="AgentsConstants.AgentNames.Auto"/>, the master intent router. When the configured agent is not
+        /// registered either, <see cref="AgentsConstants.AgentNames.Knowledge"/> is used.
+        /// </summary>
+        public string DefaultAgent { get; set; } = AgentsConstants.AgentNames.Auto;
     }
 }
 

--- a/src/Indice.Features.Agents.Core/AgentsOptionsValidator.cs
+++ b/src/Indice.Features.Agents.Core/AgentsOptionsValidator.cs
@@ -29,6 +29,8 @@ public sealed class AgentsOptionsValidator : IValidateOptions<AgentsOptions>
             failures.Add("Dex:Taxonomy:Languages must contain at least one non-empty string.");
         if (options.Retrieval.RerankSnippetLength <= 0)
             failures.Add("Dex:Retrieval:RerankSnippetLength must be positive.");
+        if (string.IsNullOrWhiteSpace(options.Routing.DefaultAgent))
+            failures.Add("Dex:Routing:DefaultAgent must name a registered agent (e.g. \"auto\" or \"knowledge\").");
 
         return failures.Count > 0
             ? ValidateOptionsResult.Fail(failures)

--- a/src/Indice.Features.Agents.Core/AgentsRegistrationExtensions.cs
+++ b/src/Indice.Features.Agents.Core/AgentsRegistrationExtensions.cs
@@ -1,0 +1,50 @@
+using Indice.Features.Agents.Core;
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Workflows;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>Registers routable agents into the Agents catalogue consumed by the chat client, the intent router and the discovery endpoint.</summary>
+public static class AgentsRegistrationExtensions
+{
+    /// <summary>
+    /// Registers a ready-made agent. <see cref="AgentDefinition.CreateAgent"/> must be set. The definition becomes resolvable as
+    /// <c>IEnumerable&lt;AgentDefinition&gt;</c>; agent names are unique (case-insensitive).
+    /// </summary>
+    /// <exception cref="ArgumentException">The definition has no name or no <see cref="AgentDefinition.CreateAgent"/> factory.</exception>
+    /// <exception cref="InvalidOperationException">An agent with the same name is already registered.</exception>
+    public static IServiceCollection AddAgent(this IServiceCollection services, AgentDefinition definition) {
+        ArgumentNullException.ThrowIfNull(definition);
+        if (string.IsNullOrWhiteSpace(definition.Name)) {
+            throw new ArgumentException("An agent definition must have a name.", nameof(definition));
+        }
+        if (definition.CreateAgent is null) {
+            throw new ArgumentException($"Agent '{definition.Name}' has no CreateAgent factory. Use AddAgentWorkflow for workflow-backed agents.", nameof(definition));
+        }
+        var duplicate = services.Any(descriptor =>
+            descriptor.ServiceType == typeof(AgentDefinition) &&
+            descriptor.ImplementationInstance is AgentDefinition existing &&
+            string.Equals(existing.Name, definition.Name, StringComparison.OrdinalIgnoreCase));
+        if (duplicate) {
+            throw new InvalidOperationException($"An agent named '{definition.Name}' is already registered.");
+        }
+        services.AddSingleton(definition);
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a MAF <see cref="Workflow"/> as a routable agent. The workflow is registered as a keyed scoped <see cref="Workflow"/>
+    /// under the agent name and wrapped with <c>AsAIAgent</c> per request, so its start executor must accept chat messages
+    /// (see <c>KnowledgeEntry</c> for the pipeline entry point pattern).
+    /// </summary>
+    public static IServiceCollection AddAgentWorkflow(this IServiceCollection services, AgentDefinition definition, Func<IServiceProvider, Workflow> workflowFactory) {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(workflowFactory);
+        var name = definition.Name;
+        services.AddKeyedScoped(name, (serviceProvider, _) => workflowFactory(serviceProvider));
+        definition.CreateAgent = serviceProvider => serviceProvider
+            .GetRequiredKeyedService<Workflow>(name)
+            .AsAIAgent(id: name, name: name, description: definition.Description, includeExceptionDetails: true);
+        return services.AddAgent(definition);
+    }
+}

--- a/src/Indice.Features.Agents.Core/Services/ConversationStoreChatHistoryProvider.cs
+++ b/src/Indice.Features.Agents.Core/Services/ConversationStoreChatHistoryProvider.cs
@@ -41,9 +41,14 @@ public sealed class ConversationStoreChatHistoryProvider : ChatHistoryProvider
         => _sessionState.SaveState(agentSession, new State { ConversationId = conversationId });
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Resolves the conversation from the session state stamped via <see cref="SetSessionId"/>; when the session was created by the
+    /// Agent Framework itself (a handoff participant, a workflow hosted as an agent) and carries no id, falls back to the
+    /// <c>conversationId</c> property stamped on the request messages (see <c>ConversationMessageExtensions</c>).
+    /// </remarks>
     protected override async ValueTask<IEnumerable<Microsoft.Extensions.AI.ChatMessage>> ProvideChatHistoryAsync(InvokingContext context, CancellationToken cancellationToken = default) {
         var conversationId = _sessionState.GetOrInitializeState(context.Session).ConversationId;
-        if (conversationId == Guid.Empty) {
+        if (conversationId == Guid.Empty && !context.RequestMessages.TryGetConversationId(out conversationId)) {
             return [];
         }
         var history = await _store.GetHistoryAsync(conversationId, cancellationToken);

--- a/src/Indice.Features.Agents.Core/Workflows/ConversationMessageExtensions.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/ConversationMessageExtensions.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.AI;
+
+namespace Indice.Features.Agents.Core.Workflows;
+
+/// <summary>
+/// Carries the Dex conversation id on a <see cref="ChatMessage"/> (<see cref="AgentsConstants.MessageProperties.ConversationId"/>),
+/// so components that receive messages through the Agent Framework, without access to the run's session or workflow state, can
+/// still find the conversation: the pipeline entry executor of a workflow hosted as an agent, and the history provider of a
+/// handoff participant whose session is created by the framework.
+/// </summary>
+public static class ConversationMessageExtensions
+{
+    /// <summary>Stamps <paramref name="conversationId"/> onto the message's additional properties.</summary>
+    public static ChatMessage SetConversationId(this ChatMessage message, Guid conversationId) {
+        ArgumentNullException.ThrowIfNull(message);
+        message.AdditionalProperties ??= new AdditionalPropertiesDictionary();
+        message.AdditionalProperties[AgentsConstants.MessageProperties.ConversationId] = conversationId.ToString();
+        return message;
+    }
+
+    /// <summary>Reads the conversation id stamped on the message, accepting either a <see cref="Guid"/> or its string form.</summary>
+    public static bool TryGetConversationId(this ChatMessage message, out Guid conversationId) {
+        conversationId = Guid.Empty;
+        if (message?.AdditionalProperties is null || !message.AdditionalProperties.TryGetValue(AgentsConstants.MessageProperties.ConversationId, out var raw)) {
+            return false;
+        }
+        switch (raw) {
+            case Guid guid when guid != Guid.Empty:
+                conversationId = guid;
+                return true;
+            case string text when Guid.TryParse(text, out var parsed) && parsed != Guid.Empty:
+                conversationId = parsed;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>Reads the conversation id from the most recent message that carries one.</summary>
+    public static bool TryGetConversationId(this IEnumerable<ChatMessage> messages, out Guid conversationId) {
+        conversationId = Guid.Empty;
+        if (messages is null) {
+            return false;
+        }
+        foreach (var message in messages.Reverse()) {
+            if (message.TryGetConversationId(out conversationId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Indice.Features.Agents.Core/Workflows/Events/StepProgressWorkflowContextExtensions.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Events/StepProgressWorkflowContextExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.AI;
+
+namespace Indice.Features.Agents.Core.Workflows.Events;
+
+/// <summary>Progress reporting for pipeline steps.</summary>
+public static class StepProgressWorkflowContextExtensions
+{
+    /// <summary>
+    /// Emits an ephemeral <see cref="StepProgressContent"/> update for the step identified by <paramref name="executorId"/>.
+    /// Rides the same <see cref="AgentResponseUpdateEvent"/> channel as streamed text, so it survives when the workflow is hosted
+    /// as an agent (where executor lifecycle events are not forwarded), and is stripped before the turn is persisted.
+    /// </summary>
+    public static ValueTask EmitProgressAsync(this IWorkflowContext context, string executorId, string label, CancellationToken cancellationToken = default)
+        => context.AddEventAsync(new AgentResponseUpdateEvent(executorId, new AgentResponseUpdate(ChatRole.Assistant, [new StepProgressContent(label)])), cancellationToken);
+}

--- a/src/Indice.Features.Agents.Core/Workflows/Prompts/FileSystemPromptTemplateRenderer.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Prompts/FileSystemPromptTemplateRenderer.cs
@@ -30,6 +30,7 @@ public sealed class FileSystemPromptTemplateRenderer : IPromptTemplateRenderer
                     nameof(AgentsConstants.PromptDefaults.IntentClassifier) => _handlebars.Compile(AgentsConstants.PromptDefaults.IntentClassifier),
                     nameof(AgentsConstants.PromptDefaults.PurposeResponder) => _handlebars.Compile(AgentsConstants.PromptDefaults.PurposeResponder),
                     nameof(AgentsConstants.PromptDefaults.QueryRewriter) => _handlebars.Compile(AgentsConstants.PromptDefaults.QueryRewriter),
+                    nameof(AgentsConstants.PromptDefaults.IntentRouter) => _handlebars.Compile(AgentsConstants.PromptDefaults.IntentRouter),
                     _ => throw new InvalidOperationException($"Prompt template '{name}' not found at '{path}'."),
                 };
             }

--- a/src/Indice.Features.Agents.Core/Workflows/Routing/IntentRouterFactory.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Routing/IntentRouterFactory.cs
@@ -1,0 +1,68 @@
+using Indice.Features.Agents.Core.Workflows.Prompts;
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Indice.Features.Agents.Core.Workflows.Routing;
+
+/// <summary>
+/// Builds the master intent router as a Microsoft Agent Framework handoff orchestration: a triage agent that reads the latest user
+/// message in the context of the conversation and hands the turn off, through a tool call, to exactly one registered agent.
+/// Targets are every <see cref="AgentDefinition"/> in the catalogue that is not itself a router.
+/// </summary>
+public static class IntentRouterFactory
+{
+    /// <summary>
+    /// Creates the handoff workflow for the current request: router → one of the registered target agents. There are no
+    /// return handoffs and no autonomous continuation, so a turn ends as soon as the chosen agent answers.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No routable agent is registered.</exception>
+    public static Workflow CreateHandoffWorkflow(IServiceProvider serviceProvider) {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        var targets = serviceProvider.GetServices<AgentDefinition>().Where(definition => !definition.IsRouter).ToList();
+        if (targets.Count == 0) {
+            throw new InvalidOperationException("No routable agents are registered. Register at least one agent with AddAgent or AddAgentWorkflow before using the intent router.");
+        }
+        var router = CreateRouterAgent(serviceProvider, targets);
+        var agents = targets.Select(definition => definition.CreateAgent!(serviceProvider)).ToList();
+        return AgentWorkflowBuilder.CreateHandoffBuilderWith(router)
+            .WithHandoffs(router, agents)
+            .Build();
+    }
+
+    /// <summary>
+    /// Creates the triage agent on the fast deployment. Its instructions list every target (name + description) rendered from the
+    /// <c>IntentRouter</c> prompt template, it sees the conversation history through <see cref="ConversationStoreChatHistoryProvider"/>,
+    /// and it is forced to call a tool so it can never answer in prose.
+    /// </summary>
+    public static AIAgent CreateRouterAgent(IServiceProvider serviceProvider, IReadOnlyList<AgentDefinition> targets) {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(targets);
+        var chatClient = serviceProvider.GetRequiredKeyedService<IChatClient>(nameof(AgentsOptions.AzureOpenAIDeployments.Fast));
+        var models = serviceProvider.GetRequiredService<IOptions<ModelsOptions>>().Value;
+        var prompts = serviceProvider.GetRequiredService<IPromptTemplateRenderer>();
+        var historyProvider = serviceProvider.GetRequiredService<ConversationStoreChatHistoryProvider>();
+
+        var defaultTarget = targets.FirstOrDefault(definition => string.Equals(definition.Name, AgentsConstants.AgentNames.Knowledge, StringComparison.OrdinalIgnoreCase))
+            ?? targets[0];
+        var chatOptions = models.BaseFastModelOptions.Clone();
+        chatOptions.Instructions = prompts.Render(nameof(AgentsConstants.PromptDefaults.IntentRouter), new {
+            agents = targets.Select(definition => new { name = definition.Name, description = definition.Description }).ToList(),
+            defaultTarget = defaultTarget.Name,
+        });
+        // The handoff tools are injected per run by the handoff executor; requiring a tool call keeps the router from replying in text.
+        chatOptions.ToolMode = ChatToolMode.RequireAny;
+
+        return chatClient.AsAIAgent(options: new ChatClientAgentOptions() {
+            Id = AgentsConstants.IntentRouter.AgentId,
+            Name = AgentsConstants.IntentRouter.AgentName,
+            Description = "Routes each turn to the agent best suited to answer it.",
+            ChatOptions = chatOptions,
+            ChatHistoryProvider = historyProvider,
+            // Chat completions is stateless; the echoed request ConversationId must not be treated as server-side history.
+            ThrowOnChatHistoryProviderConflict = false,
+        });
+    }
+}

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/AnswerComposer.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/AnswerComposer.cs
@@ -52,6 +52,7 @@ public sealed class AnswerComposer : Executor<RerankOutput, GroundedAnswerOutput
     /// <inheritdoc/>
     public override async ValueTask<GroundedAnswerOutput> HandleAsync(RerankOutput message,
         IWorkflowContext context, CancellationToken cancellationToken = default) {
+        await context.EmitProgressAsync(Id, "Composing answer", cancellationToken);
         var state = await context.GetConversationStateAsync(cancellationToken);
         var candidates = message.RerankedCandidates;
         var prompt = BuildPrompt(state.Message.Text, candidates);

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/IntentClassifier.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/IntentClassifier.cs
@@ -48,7 +48,8 @@ public sealed class IntentClassifier : Executor<ConversationState, IntentOutput>
         ConversationState message,
         IWorkflowContext context,
         CancellationToken cancellationToken = default) {
-        var question = message.Message.Text; 
+        await context.EmitProgressAsync(Id, "Classifying intent", cancellationToken);
+        var question = message.Message.Text;
         var conversationId = message.ConversationId;
         await context.SetConversationStateAsync(message, cancellationToken);
         var agentSession = await _agent.CreateSessionAsync(cancellationToken);

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/KnowledgeEntry.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/KnowledgeEntry.cs
@@ -1,0 +1,26 @@
+using Indice.Features.Agents.Core.Workflows.Events;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.AI;
+
+namespace Indice.Features.Agents.Core.Workflows.Steps;
+
+/// <summary>
+/// Entry point of the knowledge pipeline when it runs as an <c>AIAgent</c>: directly, or as a handoff target of the intent router.
+/// Speaks the Agent Workflow chat protocol (accumulates incoming <see cref="ChatMessage"/>s, acts on the turn token) and forwards
+/// the turn's messages to <see cref="KnowledgeSeed"/>, which converts them into the typed <c>ConversationState</c> the pipeline
+/// expects. The two-step entry exists because the chat protocol base only lets a subclass send chat messages and turn tokens.
+/// </summary>
+public sealed class KnowledgeEntry : ChatProtocolExecutor
+{
+    /// <summary>The executor id.</summary>
+    public const string ExecutorId = "KnowledgeEntry";
+
+    /// <summary>Creates a new <see cref="KnowledgeEntry"/>.</summary>
+    public KnowledgeEntry() : base(ExecutorId, new ChatProtocolExecutorOptions { AutoSendTurnToken = false }) { }
+
+    /// <inheritdoc/>
+    protected override async ValueTask TakeTurnAsync(List<ChatMessage> messages, IWorkflowContext context, bool? emitEvents, CancellationToken cancellationToken = default) {
+        await context.EmitProgressAsync(Id, "Answering from knowledge base", cancellationToken);
+        await context.SendMessageAsync(messages, cancellationToken);
+    }
+}

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/KnowledgeSeed.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/KnowledgeSeed.cs
@@ -1,0 +1,40 @@
+using Indice.Features.Agents.Core.Workflows.State;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.AI;
+
+namespace Indice.Features.Agents.Core.Workflows.Steps;
+
+/// <summary>
+/// Second half of the agent-hosted entry (after <see cref="KnowledgeEntry"/>): seeds the typed pipeline with a
+/// <see cref="ConversationState"/> built from the turn's messages. The conversation id travels on the user message
+/// (see <see cref="ConversationMessageExtensions"/>) because the hosting agent, not this workflow, owns the session.
+/// </summary>
+public sealed class KnowledgeSeed : Executor<List<ChatMessage>, ConversationState>
+{
+    /// <summary>The executor id.</summary>
+    public const string ExecutorId = "KnowledgeSeed";
+
+    /// <summary>Creates a new <see cref="KnowledgeSeed"/>.</summary>
+    public KnowledgeSeed() : base(ExecutorId) { }
+
+    /// <inheritdoc/>
+    public override ValueTask<ConversationState> HandleAsync(List<ChatMessage> messages, IWorkflowContext context, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(CreateConversationState(messages));
+
+    /// <summary>
+    /// Builds the pipeline seed from a turn's messages. Prefers the last user message that carries a conversation id (the caller's
+    /// genuine question; a handoff re-labels other agents' remarks as user messages, and those carry none), then the last user
+    /// message. The conversation id comes from that message, else from any stamped message, else it is freshly generated.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The turn holds no user message.</exception>
+    public static ConversationState CreateConversationState(IReadOnlyList<ChatMessage> messages) {
+        ArgumentNullException.ThrowIfNull(messages);
+        var message = messages.LastOrDefault(item => item.Role == ChatRole.User && item.TryGetConversationId(out _))
+            ?? messages.LastOrDefault(item => item.Role == ChatRole.User)
+            ?? throw new InvalidOperationException("The knowledge pipeline needs a user message to answer.");
+        var conversationId = message.TryGetConversationId(out var stamped) || messages.TryGetConversationId(out stamped)
+            ? stamped
+            : Guid.NewGuid();
+        return new ConversationState(message, conversationId.ToString());
+    }
+}

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/OutOfScopeResponder.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/OutOfScopeResponder.cs
@@ -1,4 +1,5 @@
 using Indice.Features.Agents.Core.Models;
+using Indice.Features.Agents.Core.Workflows.Events;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Workflows;
 using Microsoft.Extensions.AI;
@@ -20,6 +21,7 @@ public sealed class OutOfScopeResponder : Executor<IntentOutput, GroundedAnswerO
         IntentOutput intentResult,
         IWorkflowContext context,
         CancellationToken cancellationToken = default) {
+        await context.EmitProgressAsync(Id, "Preparing response", cancellationToken);
         var reason = intentResult.Intent.OutOfScopeReason ?? "Sorry, that question is outside the scope of what I can answer here.";
         await context.AddEventAsync(new AgentResponseUpdateEvent(Id,
                                         new AgentResponseUpdate(ChatRole.Assistant, reason)

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/PurposeResponder.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/PurposeResponder.cs
@@ -59,6 +59,7 @@ internal class PurposeResponder : Executor<IntentOutput, GroundedAnswerOutput>
     public override async ValueTask<GroundedAnswerOutput> HandleAsync(
         IntentOutput intentResult, IWorkflowContext context,
         CancellationToken cancellationToken = default) {
+        await context.EmitProgressAsync(Id, "Answering", cancellationToken);
         var state = await context.GetConversationStateAsync(cancellationToken);
         var prompt = state.Message.Text;
         var agentSession = await _agent.CreateSessionAsync(cancellationToken);

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/QueryRewriter.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/QueryRewriter.cs
@@ -1,4 +1,5 @@
 using Indice.Features.Agents.Core.Models;
+using Indice.Features.Agents.Core.Workflows.Events;
 using Indice.Features.Agents.Core.Workflows.Prompts;
 using Indice.Features.Agents.Core.Workflows.State;
 using Microsoft.Agents.AI;
@@ -43,6 +44,7 @@ public sealed class QueryRewriter : Executor<IntentOutput, QueryRewriteOutput>
     /// <inheritdoc/>
     public override async ValueTask<QueryRewriteOutput> HandleAsync(IntentOutput intentResult,
         IWorkflowContext context, CancellationToken cancellationToken = default) {
+        await context.EmitProgressAsync(Id, "Rewriting query", cancellationToken);
         var state = await context.GetConversationStateAsync(cancellationToken);
         var expansion = _options.Retrieval.QueryExpansion;
         var enabled = _options.Pipeline.EnableQueryRewrite && expansion > 1;

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/Reranker.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/Reranker.cs
@@ -1,4 +1,5 @@
 using Indice.Features.Agents.Core.Models;
+using Indice.Features.Agents.Core.Workflows.Events;
 using Indice.Features.Agents.Core.Workflows.Reranking;
 using Indice.Features.Agents.Core.Workflows.State;
 using Microsoft.Agents.AI.Workflows;
@@ -25,6 +26,7 @@ public sealed class Reranker : Executor<RetrievalOutput, RerankOutput>
     /// <inheritdoc/>
     public override async ValueTask<RerankOutput> HandleAsync(RetrievalOutput retrievalOutput, IWorkflowContext context,
         CancellationToken cancellationToken = default) {
+        await context.EmitProgressAsync(Id, "Ranking results", cancellationToken);
         var topResults = _options.Retrieval.NumberOfResults;
         var candidates = retrievalOutput.Candidates;
         var state = await context.GetConversationStateAsync(cancellationToken);

--- a/src/Indice.Features.Agents.Core/Workflows/Steps/Retriever.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/Steps/Retriever.cs
@@ -1,5 +1,6 @@
 using Indice.Features.Agents.Core.Models;
 using Indice.Features.Agents.Core.Services;
+using Indice.Features.Agents.Core.Workflows.Events;
 using Microsoft.Agents.AI.Workflows;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
@@ -29,6 +30,7 @@ public sealed class Retriever : Executor<QueryRewriteOutput, RetrievalOutput>
     /// <inheritdoc/>
     public override async ValueTask<RetrievalOutput> HandleAsync(
         QueryRewriteOutput queryRewriteOutput, IWorkflowContext context, CancellationToken cancellationToken = default) {
+        await context.EmitProgressAsync(Id, "Retrieving relevant context", cancellationToken);
         var filters = queryRewriteOutput.Filters;
         var topK = _options.Retrieval.NumberOfCandidates;
 

--- a/src/Indice.Features.Agents.Server/Endpoints/AgentsHandlers.cs
+++ b/src/Indice.Features.Agents.Server/Endpoints/AgentsHandlers.cs
@@ -1,40 +1,42 @@
-﻿using Indice.Features.Agents.Core;
+using Indice.Features.Agents.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Indice.Features.Agents.Server.Endpoints;
 
 internal static class AgentsHandlers
 {
-    /// <summary>Handles the discovery of available agents.</summary>
-    public static Ok<List<AgentInfo>> Discovery() {
-        // Implementation for discovering agents goes here.
-        return TypedResults.Ok(new List<AgentInfo>() { 
-            new AgentInfo(
-                Name: AgentsConstants.AgentNames.Auto,
-                Description: "This is an agent that discovers user intent and passes it to the appropriate sub agent.",
-                InputContentTypes: ["text/plain" ],
-                OutputContentTypes: ["text/markdown", AgentsConstants.MediaTypes.MultipleChoice, AgentsConstants.MediaTypes.Callout,
-                                    AgentsConstants.MediaTypes.Image, AgentsConstants.MediaTypes.Confirmation, "image/png"],
-                Capabilities: [ new AgentCapability("Master intent classification", "Discovers user intent and routes it to the appropriate sub-agent.") ],
-                Domains: [],
-                Tags: ["Intent"],
-                Links: [],
-                Icon: AgentsConstants.AgentIcons.Sparkles),
+    private static readonly List<string> InputContentTypes = ["text/plain"];
+    private static readonly List<string> OutputContentTypes = [
+        "text/markdown",
+        AgentsConstants.MediaTypes.MultipleChoice,
+        AgentsConstants.MediaTypes.Callout,
+        AgentsConstants.MediaTypes.Image,
+        AgentsConstants.MediaTypes.Confirmation,
+        "image/png"
+    ];
 
-            new AgentInfo(
-                Name: AgentsConstants.AgentNames.Knowledge,
-                Description: "This is an agent that can answer questions based on a knowledge base.",
-                InputContentTypes: ["text/plain" ],
-                OutputContentTypes: ["text/markdown", AgentsConstants.MediaTypes.MultipleChoice, AgentsConstants.MediaTypes.Callout,
-                                    AgentsConstants.MediaTypes.Image, AgentsConstants.MediaTypes.Confirmation, "image/png"],
-                Capabilities: [ new AgentCapability("Knowledge retrieval", "Answers questions based on a knowledge base.") ],
-                Domains: [],
-                Tags: ["Knowledge", "FAQ"],
-                Links: [],
-                Icon: AgentsConstants.AgentIcons.Book)
-        });
+    /// <summary>Lists the registered agents, the intent router first, then in registration order.</summary>
+    public static Ok<List<AgentInfo>> Discovery([FromServices] IEnumerable<AgentDefinition> agents) {
+        var list = agents
+            .OrderByDescending(definition => definition.IsRouter)
+            .Select(ToAgentInfo)
+            .ToList();
+        return TypedResults.Ok(list);
     }
+
+    /// <summary>Projects a catalogue entry onto the discovery contract.</summary>
+    internal static AgentInfo ToAgentInfo(AgentDefinition definition) => new(
+        Name: definition.Name,
+        Description: definition.Description,
+        InputContentTypes: [.. InputContentTypes],
+        OutputContentTypes: [.. OutputContentTypes],
+        Capabilities: definition.Capabilities.Select(capability => new AgentCapability(capability.Name, capability.Description)).ToList(),
+        Domains: [],
+        Tags: [.. definition.Tags],
+        Links: [],
+        Icon: definition.Icon);
 }
 // Rich agent metadata
 /// <summary>

--- a/test/Indice.Features.Agents.Core.Tests/Routing/AgentNameResolutionTests.cs
+++ b/test/Indice.Features.Agents.Core.Tests/Routing/AgentNameResolutionTests.cs
@@ -1,0 +1,29 @@
+namespace Indice.Features.Agents.Core.Tests.Routing;
+
+public class AgentNameResolutionTests
+{
+    private static readonly string[] Registered = ["auto", "knowledge", "Billing"];
+
+    [Theory]
+    [InlineData("knowledge", "knowledge")]
+    [InlineData("  KNOWLEDGE ", "knowledge")]
+    [InlineData("billing", "Billing")]
+    public void Returns_the_registered_spelling_of_a_known_name(string requested, string expected) {
+        Assert.Equal(expected, AgentsChatClient.ResolveAgentName(requested, Registered, "auto"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("nope")]
+    public void Falls_back_to_the_default_agent_for_missing_or_unknown_names(string? requested) {
+        Assert.Equal("auto", AgentsChatClient.ResolveAgentName(requested, Registered, "auto"));
+    }
+
+    [Fact]
+    public void Falls_back_to_knowledge_when_the_default_agent_is_not_registered() {
+        Assert.Equal("knowledge", AgentsChatClient.ResolveAgentName("nope", ["knowledge"], "auto"));
+        Assert.Equal("knowledge", AgentsChatClient.ResolveAgentName(null, ["knowledge"], null));
+    }
+}

--- a/test/Indice.Features.Agents.Core.Tests/Routing/AgentsRegistrationTests.cs
+++ b/test/Indice.Features.Agents.Core.Tests/Routing/AgentsRegistrationTests.cs
@@ -1,0 +1,66 @@
+using Indice.Features.Agents.Core.Workflows.Routing;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Indice.Features.Agents.Core.Tests.Routing;
+
+public class AgentsRegistrationTests
+{
+    private static AgentDefinition Definition(string name, bool isRouter = false) => new() {
+        Name = name,
+        Description = $"{name} agent",
+        IsRouter = isRouter,
+        CreateAgent = _ => throw new NotSupportedException("Not materialised in this test."),
+    };
+
+    [Fact]
+    public void AddAgent_exposes_the_definition_through_the_catalogue() {
+        var services = new ServiceCollection();
+        services.AddAgent(Definition("billing"));
+        services.AddAgent(Definition("auto", isRouter: true));
+
+        using var provider = services.BuildServiceProvider();
+        var names = provider.GetServices<AgentDefinition>().Select(definition => definition.Name).ToList();
+
+        Assert.Equal(["billing", "auto"], names);
+    }
+
+    [Fact]
+    public void AddAgent_rejects_duplicate_names_regardless_of_case() {
+        var services = new ServiceCollection();
+        services.AddAgent(Definition("billing"));
+
+        Assert.Throws<InvalidOperationException>(() => services.AddAgent(Definition("BILLING")));
+    }
+
+    [Fact]
+    public void AddAgent_requires_a_factory() {
+        var services = new ServiceCollection();
+        var definition = new AgentDefinition { Name = "billing", Description = "no factory" };
+
+        Assert.Throws<ArgumentException>(() => services.AddAgent(definition));
+    }
+
+    [Fact]
+    public void AddAgentWorkflow_registers_the_keyed_workflow_and_wires_the_agent_factory() {
+        var services = new ServiceCollection();
+        var definition = new AgentDefinition { Name = "echo", Description = "echoes" };
+
+        services.AddAgentWorkflow(definition, _ => throw new NotSupportedException("Not built in this test."));
+
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(Workflow) && Equals(descriptor.ServiceKey, "echo") && descriptor.Lifetime == ServiceLifetime.Scoped);
+        Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(AgentDefinition) && ReferenceEquals(descriptor.ImplementationInstance, definition));
+        Assert.NotNull(definition.CreateAgent);
+    }
+
+    [Fact]
+    public void Router_factory_refuses_to_build_without_targets() {
+        using var empty = new ServiceCollection().BuildServiceProvider();
+        Assert.Throws<InvalidOperationException>(() => IntentRouterFactory.CreateHandoffWorkflow(empty));
+
+        var services = new ServiceCollection();
+        services.AddAgent(Definition("auto", isRouter: true));
+        using var routerOnly = services.BuildServiceProvider();
+        Assert.Throws<InvalidOperationException>(() => IntentRouterFactory.CreateHandoffWorkflow(routerOnly));
+    }
+}

--- a/test/Indice.Features.Agents.Core.Tests/Routing/KnowledgeSeedTests.cs
+++ b/test/Indice.Features.Agents.Core.Tests/Routing/KnowledgeSeedTests.cs
@@ -1,0 +1,60 @@
+using Indice.Features.Agents.Core.Workflows;
+using Indice.Features.Agents.Core.Workflows.Steps;
+using Microsoft.Extensions.AI;
+
+namespace Indice.Features.Agents.Core.Tests.Routing;
+
+public class KnowledgeSeedTests
+{
+    [Fact]
+    public void Seeds_state_from_the_last_stamped_user_message() {
+        var conversationId = Guid.NewGuid();
+        var question = new ChatMessage(ChatRole.User, "How do I enable MFA?").SetConversationId(conversationId);
+        var messages = new List<ChatMessage> {
+            new(ChatRole.User, "earlier question"),
+            new(ChatRole.Assistant, "earlier answer"),
+            question,
+            // Handoff context sync re-labels other participants' remarks as user messages; they carry no conversation id.
+            new(ChatRole.User, "Routing you to the knowledge agent."),
+        };
+
+        var state = KnowledgeSeed.CreateConversationState(messages);
+
+        Assert.Same(question, state.Message);
+        Assert.Equal(conversationId.ToString(), state.ConversationId);
+    }
+
+    [Fact]
+    public void Falls_back_to_the_last_user_message_and_a_fresh_id_when_nothing_is_stamped() {
+        var messages = new List<ChatMessage> {
+            new(ChatRole.User, "first"),
+            new(ChatRole.Assistant, "reply"),
+            new(ChatRole.User, "second"),
+        };
+
+        var state = KnowledgeSeed.CreateConversationState(messages);
+
+        Assert.Equal("second", state.Message.Text);
+        Assert.True(Guid.TryParse(state.ConversationId, out var id) && id != Guid.Empty);
+    }
+
+    [Fact]
+    public void Uses_an_id_stamped_on_an_earlier_message_when_the_question_has_none() {
+        var conversationId = Guid.NewGuid();
+        var messages = new List<ChatMessage> {
+            new ChatMessage(ChatRole.System, "context").SetConversationId(conversationId),
+            new(ChatRole.User, "first"),
+            new(ChatRole.Assistant, "reply"),
+        };
+
+        var state = KnowledgeSeed.CreateConversationState(messages);
+
+        Assert.Equal("first", state.Message.Text);
+        Assert.Equal(conversationId.ToString(), state.ConversationId);
+    }
+
+    [Fact]
+    public void Throws_without_a_user_message() {
+        Assert.Throws<InvalidOperationException>(() => KnowledgeSeed.CreateConversationState([new ChatMessage(ChatRole.Assistant, "hi")]));
+    }
+}


### PR DESCRIPTION
Introduce AgentDefinition and central catalog for agent metadata and registration. Refactor AgentsChatClient to support dynamic agent selection and streaming. Implement intent router agent with dynamic handoff workflow. Refactor knowledge pipeline to be agent-hosted with new entry and seeding steps. Standardize step progress reporting and update discovery endpoint for dynamic agent listing. Improve conversation id handling and extend prompt templates. Add RoutingOptions for configuration and new tests for agent orchestration. Enhance modularity, extensibility, and observability.