### PR TITLE
🤖[agents] Add EF-based durable checkpointing for Agents feature

### DIFF
--- a/src/Indice.Features.Agents.Core/AgentsChatClient.cs
+++ b/src/Indice.Features.Agents.Core/AgentsChatClient.cs
@@ -58,8 +58,21 @@ public class AgentsChatClient(IServiceProvider serviceProvider) : IDexChatClient
             _ => AgentsConstants.AgentNames.Knowledge
         };
         var workflow = serviceProvider.GetKeyedService<Workflow>(agenticWorkflowName) ?? serviceProvider.GetRequiredKeyedService<Workflow>(AgentsConstants.AgentNames.Knowledge);
-
-        await using var run = await InProcessExecution.RunStreamingAsync(workflow, state, sessionId: state.ConversationId, cancellationToken: cancellationToken);
+        // Checkpointing: state written via QueueStateUpdateAsync is snapshotted at each superstep into the durable
+        // EF-backed store, so it survives across HTTP requests. On a follow-up turn the latest checkpoint of the
+        // conversation (sessionId == ConversationId) is restored and the new user message is injected into the resumed run.
+        var checkpointManager = serviceProvider.GetRequiredService<CheckpointManager>();
+        var latestCheckpoint = options?.ConversationId is not null
+            ? await checkpointManager.GetLatestCheckpointAsync(state.ConversationId, cancellationToken)
+            : null;
+        StreamingRun run;
+        if (latestCheckpoint is not null) {
+            run = await InProcessExecution.ResumeStreamingAsync(workflow, latestCheckpoint, checkpointManager, cancellationToken: cancellationToken);
+            await run.TrySendMessageAsync(state);
+        } else {
+            run = await InProcessExecution.RunStreamingAsync(workflow, state, checkpointManager, sessionId: state.ConversationId, cancellationToken: cancellationToken);
+        }
+        await using var _ = run;
 
         string? failure = null;
         await foreach (var evt in run.WatchStreamAsync().WithCancellation(cancellationToken)) {

--- a/src/Indice.Features.Agents.Core/AgentsFeatureExtensions.cs
+++ b/src/Indice.Features.Agents.Core/AgentsFeatureExtensions.cs
@@ -71,6 +71,8 @@ public static class AgentsFeatureExtensions
 
         services.TryAddTransient<UserClaimsAIContextProvider>();
         services.TryAddTransient<IConversationStore, ConversationStore>();
+        services.TryAddScoped<PersistedCheckpointStore>();
+        services.TryAddScoped(sp => CheckpointManager.CreateJson(sp.GetRequiredService<PersistedCheckpointStore>()));
         services.TryAddTransient<IUsageGuardService, UsageGuardService>();
         services.TryAddTransient<ConversationStoreChatHistoryProvider>();
         services.TryAddSingleton<IPromptTemplateRenderer, FileSystemPromptTemplateRenderer>();

--- a/src/Indice.Features.Agents.Core/Data/AgentsDbContext.cs
+++ b/src/Indice.Features.Agents.Core/Data/AgentsDbContext.cs
@@ -26,6 +26,9 @@ public class AgentsDbContext : DbContext
     /// <summary>Application-local user profiles (augmenting the IdP).</summary>
     public DbSet<DbProfile> Profiles => Set<DbProfile>();
 
+    /// <summary>Durable workflow checkpoint blobs, keyed per run (conversation).</summary>
+    public DbSet<DbCheckpoint> Checkpoints => Set<DbCheckpoint>();
+
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder) {
         base.OnModelCreating(modelBuilder);

--- a/src/Indice.Features.Agents.Core/Data/DbCheckpoint.cs
+++ b/src/Indice.Features.Agents.Core/Data/DbCheckpoint.cs
@@ -1,0 +1,20 @@
+namespace Indice.Features.Agents.Core.Data;
+
+/// <summary>A durable workflow checkpoint blob. One row per committed superstep checkpoint, keyed by run (conversation) id.</summary>
+public class DbCheckpoint
+{
+    /// <summary>The workflow run identifier (the conversation id).</summary>
+    public string SessionId { get; set; } = string.Empty;
+
+    /// <summary>The checkpoint identifier assigned when the checkpoint was committed.</summary>
+    public string CheckpointId { get; set; } = string.Empty;
+
+    /// <summary>The serialized (JSON) checkpoint payload. Framework-owned shape; stored opaquely.</summary>
+    public string Payload { get; set; } = string.Empty;
+
+    /// <summary>Optional parent checkpoint id (lineage), when supplied by the runtime.</summary>
+    public string? ParentCheckpointId { get; set; }
+
+    /// <summary>Commit timestamp. Used to return the index ordered oldest-first.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/src/Indice.Features.Agents.Core/Data/Mappings/DbCheckpointMap.cs
+++ b/src/Indice.Features.Agents.Core/Data/Mappings/DbCheckpointMap.cs
@@ -1,0 +1,20 @@
+using Indice.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Indice.Features.Agents.Core.Data.Mappings;
+
+/// <summary>EF Core configuration for <see cref="DbCheckpoint"/>.</summary>
+public class DbCheckpointMap : IEntityTypeConfiguration<DbCheckpoint>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<DbCheckpoint> builder) {
+        builder.ToTable("Checkpoint", "dex");
+        builder.HasKey(x => new { x.SessionId, x.CheckpointId });
+        builder.Property(x => x.SessionId).HasMaxLength(TextSizePresets.M128).IsRequired();
+        builder.Property(x => x.CheckpointId).HasMaxLength(TextSizePresets.M128).IsRequired();
+        builder.Property(x => x.ParentCheckpointId).HasMaxLength(TextSizePresets.M128);
+        builder.Property(x => x.Payload).IsRequired();
+        builder.HasIndex(x => new { x.SessionId, x.CreatedAt });
+    }
+}

--- a/src/Indice.Features.Agents.Core/Indice.Features.Agents.Core.csproj
+++ b/src/Indice.Features.Agents.Core/Indice.Features.Agents.Core.csproj
@@ -12,12 +12,12 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.20.0" />
+    <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.20.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
-    <PackageReference Include="ModelContextProtocol.Core" Version="1.4.0" />
+    <PackageReference Include="ModelContextProtocol.Core" Version="2.2.0" />
 
     <!-- 3rd Party -->
     <PackageReference Include="Duende.IdentityModel" Version="8.1.0" />

--- a/src/Indice.Features.Agents.Core/Services/ConversationStore.cs
+++ b/src/Indice.Features.Agents.Core/Services/ConversationStore.cs
@@ -214,6 +214,9 @@ public class ConversationStore : IConversationStore
         await _db.Messages
             .Where(m => m.ConversationId == conversationId)
             .ExecuteDeleteAsync(cancellationToken);
+        await _db.Checkpoints
+            .Where(c => c.SessionId == conversationId.ToString())
+            .ExecuteDeleteAsync(cancellationToken);
         var deleted = await _db.Conversations
             .Where(s => s.Id == conversationId && s.UserId == userId)
             .ExecuteDeleteAsync(cancellationToken);

--- a/src/Indice.Features.Agents.Core/Workflows/PersistedCheckpointStore.cs
+++ b/src/Indice.Features.Agents.Core/Workflows/PersistedCheckpointStore.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using Indice.Features.Agents.Core.Data;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.Agents.AI.Workflows.Checkpointing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Indice.Features.Agents.Core.Workflows;
+
+/// <summary>
+/// A durable <see cref="JsonCheckpointStore"/> backed by <see cref="AgentsDbContext"/> (table <c>dex.Checkpoint</c>).
+/// Checkpoint payloads are stored opaquely as JSON; the index is returned ordered by commit time, oldest first,
+/// as required by <see cref="CheckpointManager"/> to resolve the latest checkpoint of a run.
+/// </summary>
+public sealed class PersistedCheckpointStore(AgentsDbContext dbContext) : JsonCheckpointStore
+{
+    /// <inheritdoc/>
+    public override async ValueTask<CheckpointInfo> CreateCheckpointAsync(string sessionId, JsonElement value, CheckpointInfo? parent = null) {
+        var checkpointInfo = new CheckpointInfo(sessionId, Guid.CreateVersion7().ToString("N"));
+        dbContext.Set<DbCheckpoint>().Add(new DbCheckpoint {
+            SessionId = sessionId,
+            CheckpointId = checkpointInfo.CheckpointId,
+            ParentCheckpointId = parent?.CheckpointId,
+            Payload = value.GetRawText(),
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+        return checkpointInfo;
+    }
+
+    /// <inheritdoc/>
+    public override async ValueTask<JsonElement> RetrieveCheckpointAsync(string sessionId, CheckpointInfo key) {
+        var row = await dbContext.Set<DbCheckpoint>()
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.SessionId == sessionId && x.CheckpointId == key.CheckpointId)
+            ?? throw new KeyNotFoundException($"Checkpoint '{key.CheckpointId}' was not found for run '{sessionId}'.");
+        using var document = JsonDocument.Parse(row.Payload);
+        return document.RootElement.Clone();
+    }
+
+    /// <inheritdoc/>
+    public override async ValueTask<IEnumerable<CheckpointInfo>> RetrieveIndexAsync(string sessionId, CheckpointInfo? withAncestor = null) {
+        var query = dbContext.Set<DbCheckpoint>().AsNoTracking().Where(x => x.SessionId == sessionId);
+        if (withAncestor is not null) {
+            query = query.Where(x => x.ParentCheckpointId == withAncestor.CheckpointId);
+        }
+        // Materialize then order client-side: index sets are small per run and some providers (e.g. SQLite in tests)
+        // cannot translate DateTimeOffset ordering. Oldest-first ordering is a CheckpointManager contract.
+        var rows = await query.Select(x => new { x.CheckpointId, x.CreatedAt }).ToListAsync();
+        return rows.OrderBy(x => x.CreatedAt).Select(x => new CheckpointInfo(sessionId, x.CheckpointId)).ToList();
+    }
+}

--- a/test/Indice.Features.Agents.Core.Tests/Indice.Features.Agents.Core.Tests.csproj
+++ b/test/Indice.Features.Agents.Core.Tests/Indice.Features.Agents.Core.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.11" />
   </ItemGroup>
 

--- a/test/Indice.Features.Agents.Core.Tests/PersistedCheckpointStoreTests.cs
+++ b/test/Indice.Features.Agents.Core.Tests/PersistedCheckpointStoreTests.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using Indice.Features.Agents.Core.Data;
+using Indice.Features.Agents.Core.Workflows;
+using Microsoft.Agents.AI.Workflows;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Indice.Features.Agents.Core.Tests;
+
+public class PersistedCheckpointStoreTests : IAsyncLifetime
+{
+
+    public ServiceProvider ServiceProvider { get; }
+
+    public PersistedCheckpointStoreTests() {
+        var services = new ServiceCollection();
+        services.AddDbContext<AgentsDbContext>(builder => builder.UseInMemoryDatabase(databaseName: "AgentsDb"), ServiceLifetime.Singleton);
+        ServiceProvider = services.BuildServiceProvider();
+    }
+
+    public ValueTask InitializeAsync() {
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync() {
+        await ServiceProvider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task CreateAndRetrieve_RoundTrips_Payload() {
+        var db = ServiceProvider.GetRequiredService<AgentsDbContext>();
+        var store = new PersistedCheckpointStore(db);
+        var runId = Guid.NewGuid().ToString();
+        var payload = JsonDocument.Parse("""{"answer":42,"nested":{"text":"hello"}}""").RootElement;
+
+        var info = await store.CreateCheckpointAsync(runId, payload);
+        var retrieved = await store.RetrieveCheckpointAsync(runId, info);
+
+        Assert.Equal(runId, info.SessionId);
+        Assert.Equal(42, retrieved.GetProperty("answer").GetInt32());
+        Assert.Equal("hello", retrieved.GetProperty("nested").GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public async Task RetrieveIndex_ReturnsCheckpoints_OldestFirst() {
+        var runId = Guid.NewGuid().ToString();
+        var first = await CreateCheckpointAsync(runId, """{"step":1}""");
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+        var second = await CreateCheckpointAsync(runId, """{"step":2}""");
+
+        var db = ServiceProvider.GetRequiredService<AgentsDbContext>();
+        var index = (await new PersistedCheckpointStore(db).RetrieveIndexAsync(runId)).ToList();
+
+        Assert.Equal(2, index.Count);
+        Assert.Equal(first.CheckpointId, index[0].CheckpointId);
+        Assert.Equal(second.CheckpointId, index[1].CheckpointId);
+    }
+
+    [Fact]
+    public async Task Checkpoints_SurviveAcrossDbContextInstances() {
+        var runId = Guid.NewGuid().ToString();
+        var info = await CreateCheckpointAsync(runId, """{"conversationState":"persisted"}""");
+
+        // Fresh context simulates a new HTTP request / service scope.
+        var db = ServiceProvider.GetRequiredService<AgentsDbContext>();
+        var retrieved = await new PersistedCheckpointStore(db).RetrieveCheckpointAsync(runId, info);
+
+        Assert.Equal("persisted", retrieved.GetProperty("conversationState").GetString());
+    }
+
+    [Fact]
+    public async Task RetrieveCheckpoint_UnknownId_Throws() {
+        var db = ServiceProvider.GetRequiredService<AgentsDbContext>();
+        var store = new PersistedCheckpointStore(db);
+        await Assert.ThrowsAsync<KeyNotFoundException>(async () =>
+            await store.RetrieveCheckpointAsync("missing-run", new CheckpointInfo("missing-run", "missing-checkpoint")));
+    }
+
+    [Fact]
+    public async Task CheckpointManager_GetLatestCheckpointAsync_ResolvesMostRecent() {
+        var runId = Guid.NewGuid().ToString();
+        await CreateCheckpointAsync(runId, """{"step":1}""");
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+        var latest = await CreateCheckpointAsync(runId, """{"step":2}""");
+
+        var db = ServiceProvider.GetRequiredService<AgentsDbContext>();
+        var manager = CheckpointManager.CreateJson(new PersistedCheckpointStore(db));
+        var resolved = await manager.GetLatestCheckpointAsync(runId, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(resolved);
+        Assert.Equal(latest.CheckpointId, resolved!.CheckpointId);
+    }
+
+    private async Task<CheckpointInfo> CreateCheckpointAsync(string runId, string json) {
+        var db = ServiceProvider.GetRequiredService<AgentsDbContext>();
+        return await new PersistedCheckpointStore(db).CreateCheckpointAsync(runId, JsonDocument.Parse(json).RootElement);
+    }
+}


### PR DESCRIPTION
Implemented workflow checkpoint persistence using EF and a new DbCheckpoint entity. Added PersistedCheckpointStore and integrated with DI. Updated AgentsChatClient for state recovery and ensured checkpoint cleanup on conversation deletion. Upgraded dependencies and added tests for checkpoint management.